### PR TITLE
feat: show user listings with images and editing

### DIFF
--- a/app/sell/[uid]/[propertyId]/edit/page.tsx
+++ b/app/sell/[uid]/[propertyId]/edit/page.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { useAuthContext } from "@/contexts/AuthContext"
+import { getDocument, updateDocument } from "@/lib/firestore"
+
+interface Props {
+  params: { uid: string; propertyId: string }
+}
+
+export default function EditPropertyPage({ params }: Props) {
+  const { uid, propertyId } = params
+  const router = useRouter()
+  const { user, loading } = useAuthContext()
+  const [title, setTitle] = useState("")
+  const [price, setPrice] = useState("")
+  const [description, setDescription] = useState("")
+  const [photos, setPhotos] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!loading && user && user.uid !== uid) {
+      router.replace(`/sell/${uid}/${propertyId}`)
+    }
+  }, [user, loading, uid, propertyId, router])
+
+  useEffect(() => {
+    const fetch = async () => {
+      const doc = await getDocument(`users/${uid}/user_property`, propertyId)
+      if (doc) {
+        const data = doc.data() as any
+        setTitle(data.title || "")
+        setPrice(data.price || "")
+        setDescription(data.description || "")
+        if (Array.isArray(data.photos)) setPhotos(data.photos)
+      }
+    }
+    fetch()
+  }, [uid, propertyId])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await updateDocument(`users/${uid}/user_property`, propertyId, {
+      title,
+      price,
+      description,
+    })
+    router.push(`/sell/${uid}/${propertyId}`)
+  }
+
+  if (loading || !user) return null
+
+  return (
+    <div className="max-w-2xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">แก้ไขประกาศ</h1>
+      {photos.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 mb-4">
+          {photos.map((url, idx) => (
+            <img
+              key={idx}
+              src={url}
+              alt={title || `photo-${idx}`}
+              className="w-full h-32 object-cover rounded"
+            />
+          ))}
+        </div>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1 text-sm font-medium">ชื่อประกาศ</label>
+          <Input value={title} onChange={(e) => setTitle(e.target.value)} required />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm font-medium">ราคา</label>
+          <Input value={price} onChange={(e) => setPrice(e.target.value)} required />
+        </div>
+        <div>
+          <label className="block mb-1 text-sm font-medium">รายละเอียด</label>
+          <Textarea value={description} onChange={(e) => setDescription(e.target.value)} required />
+        </div>
+        <Button type="submit">บันทึก</Button>
+      </form>
+    </div>
+  )
+}

--- a/app/sell/[uid]/[propertyId]/page.tsx
+++ b/app/sell/[uid]/[propertyId]/page.tsx
@@ -2,10 +2,14 @@
 
 import Link from "next/link"
 import { useEffect, useState } from "react"
+import { Bed, Bath, MapPin, Square } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import { useAuthContext } from "@/contexts/AuthContext"
 import { getDocument } from "@/lib/firestore"
-import { Bed, Bath, MapPin, Square } from "lucide-react"
 
 interface Props {
   params: { uid: string; propertyId: string }
@@ -15,6 +19,8 @@ export default function PropertyPage({ params }: Props) {
   const { uid, propertyId } = params
   const { user } = useAuthContext()
   const [property, setProperty] = useState<any | null>(null)
+  const [owner, setOwner] = useState<any | null>(null)
+  const [activePhoto, setActivePhoto] = useState(0)
 
   useEffect(() => {
     const fetch = async () => {
@@ -22,66 +28,136 @@ export default function PropertyPage({ params }: Props) {
       if (doc) {
         setProperty({ id: doc.id, ...doc.data() })
       }
+      const ownerDoc = await getDocument("users", uid)
+      if (ownerDoc) {
+        setOwner(ownerDoc.data())
+      }
     }
     fetch()
   }, [uid, propertyId])
 
   if (!property) return <p className="p-4">กำลังโหลด...</p>
 
+  const photos: string[] = Array.isArray(property.photos) ? property.photos : []
+
   return (
-    <div className="max-w-4xl mx-auto p-4 space-y-6">
-      <h1 className="text-3xl font-bold">{property.title}</h1>
-      {property.price && (
-        <p className="text-2xl font-semibold text-blue-600">{property.price}</p>
-      )}
-      {(property.address || property.city || property.province) && (
-        <p className="text-gray-600 flex items-center">
-          <MapPin className="w-4 h-4 mr-1" />
-          {[property.address, property.city, property.province].filter(Boolean).join(", ")}
-        </p>
-      )}
-      {Array.isArray(property.photos) && property.photos.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-          {property.photos.map((url: string, idx: number) => (
-            <img
-              key={idx}
-              src={url}
-              alt={property.title || `photo-${idx}`}
-              className="w-full h-48 object-cover rounded"
-            />
-          ))}
+    <div className="max-w-6xl mx-auto p-4 space-y-8">
+      <div className="grid md:grid-cols-2 gap-8">
+        <div className="space-y-4">
+          {photos.length > 0 ? (
+            <>
+              <img
+                src={photos[activePhoto]}
+                alt={property.title || "property-photo"}
+                className="w-full h-64 md:h-96 object-cover rounded-lg"
+              />
+              {photos.length > 1 && (
+                <div className="flex gap-2 overflow-x-auto">
+                  {photos.map((url, idx) => (
+                    <img
+                      key={idx}
+                      src={url}
+                      alt={property.title || `thumb-${idx}`}
+                      onClick={() => setActivePhoto(idx)}
+                      className={`w-20 h-20 object-cover rounded cursor-pointer border-2 ${
+                        idx === activePhoto ? "border-blue-500" : "border-transparent"
+                      }`}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="w-full h-64 md:h-96 bg-gray-200 rounded" />
+          )}
         </div>
-      )}
-      <div className="flex flex-wrap gap-4 text-gray-700">
-        {property.bedrooms && (
-          <span className="flex items-center">
-            <Bed className="w-4 h-4 mr-1" /> {property.bedrooms} ห้องนอน
-          </span>
-        )}
-        {property.bathrooms && (
-          <span className="flex items-center">
-            <Bath className="w-4 h-4 mr-1" /> {property.bathrooms} ห้องน้ำ
-          </span>
-        )}
-        {property.usableArea && (
-          <span className="flex items-center">
-            <Square className="w-4 h-4 mr-1" /> พื้นที่ใช้สอย {property.usableArea}
-          </span>
-        )}
-        {property.landArea && (
-          <span className="flex items-center">
-            <Square className="w-4 h-4 mr-1" /> พื้นที่ดิน {property.landArea}
-          </span>
-        )}
+
+        <div className="space-y-4">
+          <h1 className="text-3xl font-bold">{property.title}</h1>
+          {property.price && (
+            <p className="text-2xl font-semibold text-blue-600">{property.price}</p>
+          )}
+          {(property.address || property.city || property.province) && (
+            <p className="text-gray-600 flex items-center">
+              <MapPin className="w-4 h-4 mr-1" />
+              {[property.address, property.city, property.province].filter(Boolean).join(", ")}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-4 text-gray-700">
+            {property.bedrooms && (
+              <span className="flex items-center">
+                <Bed className="w-4 h-4 mr-1" /> {property.bedrooms} ห้องนอน
+              </span>
+            )}
+            {property.bathrooms && (
+              <span className="flex items-center">
+                <Bath className="w-4 h-4 mr-1" /> {property.bathrooms} ห้องน้ำ
+              </span>
+            )}
+            {property.usableArea && (
+              <span className="flex items-center">
+                <Square className="w-4 h-4 mr-1" /> พื้นที่ใช้สอย {property.usableArea}
+              </span>
+            )}
+            {property.landArea && (
+              <span className="flex items-center">
+                <Square className="w-4 h-4 mr-1" /> พื้นที่ดิน {property.landArea}
+              </span>
+            )}
+          </div>
+          {property.description && (
+            <p className="text-gray-700 whitespace-pre-line">{property.description}</p>
+          )}
+          {user?.uid === uid && (
+            <Link href={`/sell/${uid}/${propertyId}/edit`}>
+              <Button>แก้ไขประกาศ</Button>
+            </Link>
+          )}
+        </div>
       </div>
-      {property.description && (
-        <p className="text-gray-700 whitespace-pre-line">{property.description}</p>
-      )}
-      {user?.uid === uid && (
-        <Link href={`/sell/${uid}/${propertyId}/edit`}>
-          <Button>แก้ไขประกาศ</Button>
-        </Link>
-      )}
+
+      <div className="grid md:grid-cols-2 gap-8">
+        <div />
+        <div className="space-y-4">
+          <div className="border rounded-lg p-4 space-y-4">
+            <h2 className="text-lg font-semibold">ติดต่อเอเจนซี่</h2>
+            <div className="space-y-2">
+              <div className="space-y-1">
+                <Label htmlFor="name">ชื่อ</Label>
+                <Input id="name" placeholder="ชื่อของคุณ" />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="phone">เบอร์โทรศัพท์</Label>
+                <Input id="phone" placeholder="08x-xxx-xxxx" />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="message">ข้อความ</Label>
+                <Textarea id="message" rows={3} />
+              </div>
+              <Button className="w-full">ส่งข้อความ</Button>
+            </div>
+          </div>
+
+          {owner && (
+            <div className="flex items-center gap-3 p-4 border rounded-lg">
+              {owner.photoURL && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={owner.photoURL}
+                  alt={owner.name || "agent"}
+                  className="w-12 h-12 rounded-full object-cover"
+                />
+              )}
+              <div>
+                <p className="font-medium">{owner.name}</p>
+                {owner.phoneNumber && (
+                  <p className="text-sm text-gray-600">{owner.phoneNumber}</p>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/app/sell/[uid]/[propertyId]/page.tsx
+++ b/app/sell/[uid]/[propertyId]/page.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import Link from "next/link"
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { useAuthContext } from "@/contexts/AuthContext"
+import { getDocument } from "@/lib/firestore"
+
+interface Props {
+  params: { uid: string; propertyId: string }
+}
+
+export default function PropertyPage({ params }: Props) {
+  const { uid, propertyId } = params
+  const { user } = useAuthContext()
+  const [property, setProperty] = useState<any | null>(null)
+
+  useEffect(() => {
+    const fetch = async () => {
+      const doc = await getDocument(`users/${uid}/user_property`, propertyId)
+      if (doc) {
+        setProperty({ id: doc.id, ...doc.data() })
+      }
+    }
+    fetch()
+  }, [uid, propertyId])
+
+  if (!property) return <p className="p-4">กำลังโหลด...</p>
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-6">
+      <h1 className="text-3xl font-bold">{property.title}</h1>
+      {Array.isArray(property.photos) && property.photos.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+          {property.photos.map((url: string, idx: number) => (
+            <img
+              key={idx}
+              src={url}
+              alt={property.title || `photo-${idx}`}
+              className="w-full h-48 object-cover rounded"
+            />
+          ))}
+        </div>
+      )}
+      {property.price && (
+        <p className="text-xl text-blue-600">{property.price}</p>
+      )}
+      {property.description && (
+        <p className="text-gray-700 whitespace-pre-line">{property.description}</p>
+      )}
+      {user?.uid === uid && (
+        <Link href={`/sell/${uid}/${propertyId}/edit`}>
+          <Button>แก้ไขประกาศ</Button>
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/app/sell/[uid]/[propertyId]/page.tsx
+++ b/app/sell/[uid]/[propertyId]/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { useAuthContext } from "@/contexts/AuthContext"
 import { getDocument } from "@/lib/firestore"
+import { Bed, Bath, MapPin, Square } from "lucide-react"
 
 interface Props {
   params: { uid: string; propertyId: string }
@@ -30,6 +31,15 @@ export default function PropertyPage({ params }: Props) {
   return (
     <div className="max-w-4xl mx-auto p-4 space-y-6">
       <h1 className="text-3xl font-bold">{property.title}</h1>
+      {property.price && (
+        <p className="text-2xl font-semibold text-blue-600">{property.price}</p>
+      )}
+      {(property.address || property.city || property.province) && (
+        <p className="text-gray-600 flex items-center">
+          <MapPin className="w-4 h-4 mr-1" />
+          {[property.address, property.city, property.province].filter(Boolean).join(", ")}
+        </p>
+      )}
       {Array.isArray(property.photos) && property.photos.length > 0 && (
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
           {property.photos.map((url: string, idx: number) => (
@@ -42,9 +52,28 @@ export default function PropertyPage({ params }: Props) {
           ))}
         </div>
       )}
-      {property.price && (
-        <p className="text-xl text-blue-600">{property.price}</p>
-      )}
+      <div className="flex flex-wrap gap-4 text-gray-700">
+        {property.bedrooms && (
+          <span className="flex items-center">
+            <Bed className="w-4 h-4 mr-1" /> {property.bedrooms} ห้องนอน
+          </span>
+        )}
+        {property.bathrooms && (
+          <span className="flex items-center">
+            <Bath className="w-4 h-4 mr-1" /> {property.bathrooms} ห้องน้ำ
+          </span>
+        )}
+        {property.usableArea && (
+          <span className="flex items-center">
+            <Square className="w-4 h-4 mr-1" /> พื้นที่ใช้สอย {property.usableArea}
+          </span>
+        )}
+        {property.landArea && (
+          <span className="flex items-center">
+            <Square className="w-4 h-4 mr-1" /> พื้นที่ดิน {property.landArea}
+          </span>
+        )}
+      </div>
       {property.description && (
         <p className="text-gray-700 whitespace-pre-line">{property.description}</p>
       )}

--- a/app/sell/page.tsx
+++ b/app/sell/page.tsx
@@ -4,10 +4,10 @@ import Link from "next/link"
 import { useEffect, useState } from "react"
 import ChatWidget from "@/components/chat-widget"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useAuthContext } from "@/contexts/AuthContext"
 import SellAuthPrompt from "@/components/sell-auth-prompt"
 import { getDocuments } from "@/lib/firestore"
+import UserPropertyCard from "@/components/user-property-card"
 
 export default function SellDashboardPage() {
   const { user, loading } = useAuthContext()
@@ -42,44 +42,15 @@ export default function SellDashboardPage() {
       </header>
 
       {properties.length === 0 ? (
-        <Card>
-          <CardHeader>
-            <CardTitle>ประกาศของคุณ</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-gray-500">คุณยังไม่ได้สร้างประกาศขายใดๆ</p>
-          </CardContent>
-        </Card>
+        <p className="text-gray-500">คุณยังไม่ได้สร้างประกาศขายใดๆ</p>
       ) : (
-        <div className="space-y-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           {properties.map((property) => (
-            <Card key={property.id}>
-              <CardHeader>
-                <CardTitle>{property.title || "(ไม่มีชื่อ)"}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {Array.isArray(property.photos) && property.photos.length > 0 && (
-                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                    {property.photos.map((url: string, idx: number) => (
-                      <img
-                        key={idx}
-                        src={url}
-                        alt={property.title || `photo-${idx}`}
-                        className="w-full h-32 object-cover rounded"
-                      />
-                    ))}
-                  </div>
-                )}
-                <div className="flex gap-2">
-                  <Link href={`/sell/${user.uid}/${property.id}`}>
-                    <Button variant="outline">ดูรายละเอียด</Button>
-                  </Link>
-                  <Link href={`/sell/${user.uid}/${property.id}/edit`}>
-                    <Button>แก้ไข</Button>
-                  </Link>
-                </div>
-              </CardContent>
-            </Card>
+            <UserPropertyCard
+              key={property.id}
+              property={property}
+              ownerUid={user.uid}
+            />
           ))}
         </div>
       )}

--- a/app/sell/page.tsx
+++ b/app/sell/page.tsx
@@ -1,14 +1,31 @@
 "use client"
 
 import Link from "next/link"
+import { useEffect, useState } from "react"
 import ChatWidget from "@/components/chat-widget"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useAuthContext } from "@/contexts/AuthContext"
 import SellAuthPrompt from "@/components/sell-auth-prompt"
+import { getDocuments } from "@/lib/firestore"
 
 export default function SellDashboardPage() {
   const { user, loading } = useAuthContext()
+  const [properties, setProperties] = useState<any[]>([])
+
+  useEffect(() => {
+    if (!user) return
+    const fetch = async () => {
+      try {
+        const docs = await getDocuments(`users/${user.uid}/user_property`)
+        const data = docs.map((d) => ({ id: d.id, ...d.data() }))
+        setProperties(data)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetch()
+  }, [user])
 
   if (loading) return null
   if (!user) return <SellAuthPrompt />
@@ -23,14 +40,50 @@ export default function SellDashboardPage() {
           </Link>
         </div>
       </header>
-      <Card>
-        <CardHeader>
-          <CardTitle>ประกาศของคุณ</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-gray-500">คุณยังไม่ได้สร้างประกาศขายใดๆ</p>
-        </CardContent>
-      </Card>
+
+      {properties.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>ประกาศของคุณ</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-gray-500">คุณยังไม่ได้สร้างประกาศขายใดๆ</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {properties.map((property) => (
+            <Card key={property.id}>
+              <CardHeader>
+                <CardTitle>{property.title || "(ไม่มีชื่อ)"}</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {Array.isArray(property.photos) && property.photos.length > 0 && (
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                    {property.photos.map((url: string, idx: number) => (
+                      <img
+                        key={idx}
+                        src={url}
+                        alt={property.title || `photo-${idx}`}
+                        className="w-full h-32 object-cover rounded"
+                      />
+                    ))}
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <Link href={`/sell/${user.uid}/${property.id}`}>
+                    <Button variant="outline">ดูรายละเอียด</Button>
+                  </Link>
+                  <Link href={`/sell/${user.uid}/${property.id}/edit`}>
+                    <Button>แก้ไข</Button>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
       <ChatWidget />
     </div>
   )

--- a/components/featured-properties.tsx
+++ b/components/featured-properties.tsx
@@ -15,6 +15,8 @@ const featuredProperties = [
     sqft: 1200,
     type: "sale" as const,
     gradient: "bg-gradient-to-r from-blue-400 to-purple-500",
+    photos: [],
+    ownerId: ""
   },
   {
     id: 2,
@@ -26,6 +28,8 @@ const featuredProperties = [
     sqft: 950,
     type: "rent" as const,
     gradient: "bg-gradient-to-r from-green-400 to-blue-500",
+    photos: [],
+    ownerId: ""
   },
   {
     id: 3,
@@ -37,14 +41,16 @@ const featuredProperties = [
     sqft: 800,
     type: "sale" as const,
     gradient: "bg-gradient-to-r from-purple-400 to-pink-500",
+    photos: [],
+    ownerId: ""
   },
 ]
 
 export default function FeaturedProperties() {
-  const [selectedProperty, setSelectedProperty] = useState<number | null>(null)
+  const [selectedProperty, setSelectedProperty] = useState<any | null>(null)
 
-  const handleViewDetails = (id: number) => {
-    setSelectedProperty(id)
+  const handleViewDetails = (property: any) => {
+    setSelectedProperty(property)
   }
 
   const handleCloseModal = () => {
@@ -61,12 +67,16 @@ export default function FeaturedProperties() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {featuredProperties.map((property) => (
-            <PropertyCard key={property.id} {...property} onViewDetails={handleViewDetails} />
+            <PropertyCard
+              key={property.id}
+              {...property}
+              onViewDetails={() => handleViewDetails(property)}
+            />
           ))}
         </div>
       </div>
 
-      {selectedProperty && <PropertyModal propertyId={selectedProperty} onClose={handleCloseModal} />}
+      {selectedProperty && <PropertyModal property={selectedProperty} onClose={handleCloseModal} />}
     </section>
   )
 }

--- a/components/property-card.tsx
+++ b/components/property-card.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { MapPin, Bed, Bath, Square, Heart } from "lucide-react"
 
 interface PropertyCardProps {
-  id: number
+  id?: number
   title: string
   price: string
   location: string
@@ -13,7 +13,8 @@ interface PropertyCardProps {
   sqft: number
   type: "sale" | "rent"
   gradient: string
-  onViewDetails: (id: number) => void
+  image?: string
+  onViewDetails: () => void
 }
 
 export default function PropertyCard({
@@ -26,6 +27,7 @@ export default function PropertyCard({
   sqft,
   type,
   gradient,
+  image,
   onViewDetails,
 }: PropertyCardProps) {
   const [isFavorited, setIsFavorited] = useState(false)
@@ -37,11 +39,15 @@ export default function PropertyCard({
   return (
     <div className="property-card bg-white rounded-lg shadow-lg overflow-hidden transition-all duration-300 hover:transform hover:-translate-y-1 hover:shadow-xl">
       <div className="relative">
-        <div className={`h-48 ${gradient} flex items-center justify-center`}>
-          <div className="w-16 h-16 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
-            <div className="w-8 h-8 bg-white bg-opacity-40 rounded"></div>
+        {image ? (
+          <img src={image} alt={title} className="h-48 w-full object-cover" />
+        ) : (
+          <div className={`h-48 ${gradient} flex items-center justify-center`}>
+            <div className="w-16 h-16 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
+              <div className="w-8 h-8 bg-white bg-opacity-40 rounded"></div>
+            </div>
           </div>
-        </div>
+        )}
         <div
           className={`absolute top-4 left-4 ${
             type === "sale" ? "bg-green-500" : "bg-orange-500"
@@ -83,7 +89,7 @@ export default function PropertyCard({
           </span>
         </div>
         <button
-          onClick={() => onViewDetails(id)}
+          onClick={onViewDetails}
           className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition font-medium"
         >
           ดูรายละเอียด

--- a/components/property-modal.tsx
+++ b/components/property-modal.tsx
@@ -1,16 +1,23 @@
 "use client"
 
-import type React from "react"
-
+import { useEffect, useState } from "react"
+import Link from "next/link"
 import { X, Bed, Bath, Square, Check, MapPin } from "lucide-react"
-import { useEffect } from "react"
+
+import { Button } from "@/components/ui/button"
+import { useAuthContext } from "@/contexts/AuthContext"
 
 interface PropertyModalProps {
-  propertyId: number
+  property: any
   onClose: () => void
 }
 
-export default function PropertyModal({ propertyId, onClose }: PropertyModalProps) {
+export default function PropertyModal({ property, onClose }: PropertyModalProps) {
+  const { user } = useAuthContext()
+  const isOwner = user?.uid === property.ownerId
+  const [activePhoto, setActivePhoto] = useState(0)
+  const photos: string[] = Array.isArray(property.photos) ? property.photos : []
+
   useEffect(() => {
     document.body.style.overflow = "hidden"
     return () => {
@@ -18,11 +25,13 @@ export default function PropertyModal({ propertyId, onClose }: PropertyModalProp
     }
   }, [])
 
-  const handleBackdropClick = (e: React.MouseEvent) => {
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       onClose()
     }
   }
+
+  const location = [property.address, property.city, property.province].filter(Boolean).join(", ")
 
   return (
     <div
@@ -32,92 +41,106 @@ export default function PropertyModal({ propertyId, onClose }: PropertyModalProp
       <div className="bg-white rounded-lg max-w-4xl w-full max-h-screen overflow-y-auto mx-2 sm:mx-4">
         <div className="p-4 sm:p-6">
           <div className="flex justify-between items-center mb-4 sm:mb-6">
-            <h2 className="text-xl sm:text-2xl font-bold text-gray-800">รายละเอียดอสังหาริมทรัพย์</h2>
+            <h2 className="text-xl sm:text-2xl font-bold text-gray-800">
+              {property.title || "รายละเอียดอสังหาริมทรัพย์"}
+            </h2>
             <button onClick={onClose} className="text-gray-500 hover:text-gray-700 transition-colors p-1">
               <X size={24} />
             </button>
           </div>
 
-          {/* Image Gallery */}
-          <div className="mb-4 sm:mb-6">
-            <div className="h-48 sm:h-64 md:h-96 bg-gradient-to-r from-blue-400 to-purple-500 rounded-lg flex items-center justify-center mb-4">
-              <div className="w-16 sm:w-20 h-16 sm:h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
-                <div className="w-8 sm:w-10 h-8 sm:h-10 bg-white bg-opacity-40 rounded"></div>
-              </div>
-            </div>
-            <div className="grid grid-cols-4 gap-1 sm:gap-2">
-              {[
-                "bg-gradient-to-r from-green-400 to-blue-500",
-                "bg-gradient-to-r from-purple-400 to-pink-500",
-                "bg-gradient-to-r from-yellow-400 to-orange-500",
-                "bg-gradient-to-r from-teal-400 to-blue-500",
-              ].map((gradient, index) => (
-                <div
-                  key={index}
-                  className={`h-16 sm:h-20 ${gradient} rounded flex items-center justify-center cursor-pointer hover:opacity-80 transition-opacity`}
-                >
-                  <div className="w-4 sm:w-6 h-4 sm:h-6 bg-white bg-opacity-30 rounded"></div>
+          {photos.length > 0 && (
+            <div className="mb-4 sm:mb-6">
+              <img
+                src={photos[activePhoto]}
+                alt={property.title || "property-photo"}
+                className="h-48 sm:h-64 md:h-96 w-full object-cover rounded-lg mb-4"
+              />
+              {photos.length > 1 && (
+                <div className="grid grid-cols-4 gap-1 sm:gap-2">
+                  {photos.map((url, idx) => (
+                    <img
+                      key={idx}
+                      src={url}
+                      alt={property.title || `thumb-${idx}`}
+                      onClick={() => setActivePhoto(idx)}
+                      className={`h-16 sm:h-20 w-full object-cover rounded cursor-pointer ${idx === activePhoto ? "ring-2 ring-blue-500" : ""}`}
+                    />
+                  ))}
                 </div>
-              ))}
+              )}
             </div>
-          </div>
+          )}
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8">
             <div>
-              <h3 className="text-lg sm:text-xl font-semibold mb-2">บ้านครอบครัวสมัยใหม่</h3>
-              <p className="text-gray-600 mb-4 flex items-center text-sm sm:text-base">
-                <MapPin className="mr-1" size={16} />
-                123 ถนนโอ๊ค ใจกลางเมือง
-              </p>
-              <div className="text-2xl sm:text-3xl font-bold text-blue-600 mb-4 sm:mb-6">$450,000</div>
+              {location && (
+                <p className="text-gray-600 mb-4 flex items-center text-sm sm:text-base">
+                  <MapPin className="mr-1" size={16} />
+                  {location}
+                </p>
+              )}
+              {property.price && (
+                <div className="text-2xl sm:text-3xl font-bold text-blue-600 mb-4 sm:mb-6">
+                  {property.price}
+                </div>
+              )}
 
               <div className="grid grid-cols-3 gap-2 sm:gap-4 mb-4 sm:mb-6">
-                <div className="text-center p-3 sm:p-4 bg-gray-50 rounded-lg">
-                  <Bed className="mx-auto text-blue-600 mb-2" size={20} />
-                  <div className="font-semibold text-sm sm:text-base">3</div>
-                  <div className="text-xs sm:text-sm text-gray-600">ห้องนอน</div>
-                </div>
-                <div className="text-center p-3 sm:p-4 bg-gray-50 rounded-lg">
-                  <Bath className="mx-auto text-blue-600 mb-2" size={20} />
-                  <div className="font-semibold text-sm sm:text-base">2</div>
-                  <div className="text-xs sm:text-sm text-gray-600">ห้องน้ำ</div>
-                </div>
-                <div className="text-center p-3 sm:p-4 bg-gray-50 rounded-lg">
-                  <Square className="mx-auto text-blue-600 mb-2" size={20} />
-                  <div className="font-semibold text-sm sm:text-base">1,200</div>
-                  <div className="text-xs sm:text-sm text-gray-600">ตร.ฟุต</div>
-                </div>
+                {property.bedrooms && (
+                  <div className="text-center p-3 sm:p-4 bg-gray-50 rounded-lg">
+                    <Bed className="mx-auto text-blue-600 mb-2" size={20} />
+                    <div className="font-semibold text-sm sm:text-base">{property.bedrooms}</div>
+                    <div className="text-xs sm:text-sm text-gray-600">ห้องนอน</div>
+                  </div>
+                )}
+                {property.bathrooms && (
+                  <div className="text-center p-3 sm:p-4 bg-gray-50 rounded-lg">
+                    <Bath className="mx-auto text-blue-600 mb-2" size={20} />
+                    <div className="font-semibold text-sm sm:text-base">{property.bathrooms}</div>
+                    <div className="text-xs sm:text-sm text-gray-600">ห้องน้ำ</div>
+                  </div>
+                )}
+                {property.usableArea && (
+                  <div className="text-center p-3 sm:p-4 bg-gray-50 rounded-lg">
+                    <Square className="mx-auto text-blue-600 mb-2" size={20} />
+                    <div className="font-semibold text-sm sm:text-base">{property.usableArea}</div>
+                    <div className="text-xs sm:text-sm text-gray-600">ตร.ฟุต</div>
+                  </div>
+                )}
               </div>
 
-              <div className="mb-4 sm:mb-6">
-                <h4 className="font-semibold mb-2 text-sm sm:text-base">คำอธิบาย</h4>
-                <p className="text-gray-600 text-sm sm:text-base">
-                  บ้านครอบครัวสมัยใหม่ในย่านเงียบสงบ มีครัวปรับปรุงใหม่ พื้นไม้เนื้อแข็ง สวนหลังบ้านกว้างขวาง และโรงจอดรถสองคัน เหมาะสำหรับครอบครัวที่มองหาความสะดวกสบาย
-                </p>
-              </div>
-
-              <div className="mb-4 sm:mb-6">
-                <h4 className="font-semibold mb-2 text-sm sm:text-base">คุณสมบัติ</h4>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-1 sm:gap-2 text-xs sm:text-sm">
-                  {[
-                    "พื้นไม้เนื้อแข็ง",
-                    "ครัวปรับปรุงใหม่",
-                    "โรงจอดรถ 2 คัน",
-                    "สนามหลังบ้าน",
-                    "เครื่องปรับอากาศส่วนกลาง",
-                    "ใกล้โรงเรียน",
-                  ].map((feature) => (
-                    <div key={feature} className="flex items-center">
-                      <Check className="text-green-500 mr-2" size={14} />
-                      {feature}
-                    </div>
-                  ))}
+              {property.description && (
+                <div className="mb-4 sm:mb-6">
+                  <h4 className="font-semibold mb-2 text-sm sm:text-base">คำอธิบาย</h4>
+                  <p className="text-gray-600 text-sm sm:text-base whitespace-pre-line">
+                    {property.description}
+                  </p>
                 </div>
-              </div>
+              )}
+
+              {Array.isArray(property.features) && property.features.length > 0 && (
+                <div className="mb-4 sm:mb-6">
+                  <h4 className="font-semibold mb-2 text-sm sm:text-base">คุณสมบัติ</h4>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-1 sm:gap-2 text-xs sm:text-sm">
+                    {property.features.map((feature: string) => (
+                      <div key={feature} className="flex items-center">
+                        <Check className="text-green-500 mr-2" size={14} />
+                        {feature}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {isOwner && (
+                <Link href={`/sell/${property.ownerId}/${property.id}/edit`}>
+                  <Button>แก้ไขประกาศ</Button>
+                </Link>
+              )}
             </div>
 
             <div>
-              {/* Map Placeholder */}
               <div className="h-48 sm:h-64 bg-gray-200 rounded-lg mb-4 sm:mb-6 flex items-center justify-center">
                 <div className="text-center text-gray-500">
                   <MapPin className="mx-auto mb-2" size={24} />
@@ -125,7 +148,6 @@ export default function PropertyModal({ propertyId, onClose }: PropertyModalProp
                 </div>
               </div>
 
-              {/* Contact Form */}
               <div className="bg-gray-50 p-4 sm:p-6 rounded-lg">
                 <h4 className="font-semibold mb-4 text-sm sm:text-base">ติดต่อเอเจนต์</h4>
                 <div className="space-y-3 sm:space-y-4">
@@ -150,7 +172,7 @@ export default function PropertyModal({ propertyId, onClose }: PropertyModalProp
                     className="w-full px-3 sm:px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm sm:text-base"
                   />
                   <button className="w-full bg-blue-600 text-white py-2.5 sm:py-2 rounded-lg hover:bg-blue-700 transition text-sm sm:text-base">
-                    ส่งข้อความ
+                    สงข้อความ
                   </button>
                 </div>
 
@@ -174,3 +196,4 @@ export default function PropertyModal({ propertyId, onClose }: PropertyModalProp
     </div>
   )
 }
+

--- a/components/user-property-card.tsx
+++ b/components/user-property-card.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import Link from "next/link"
 import { Bed, Bath, MapPin } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import UserPropertyModal from "@/components/user-property-modal"
 
 interface UserPropertyCardProps {
   property: any
@@ -11,7 +11,7 @@ interface UserPropertyCardProps {
 
 export default function UserPropertyCard({ property, ownerUid }: UserPropertyCardProps) {
   return (
-    <div className="overflow-hidden rounded-lg border shadow-sm bg-white">
+    <div className="overflow-hidden rounded-lg border shadow-sm bg-white flex flex-col">
       {Array.isArray(property.photos) && property.photos[0] && (
         <img
           src={property.photos[0]}
@@ -19,7 +19,7 @@ export default function UserPropertyCard({ property, ownerUid }: UserPropertyCar
           className="w-full h-48 object-cover"
         />
       )}
-      <div className="p-4 space-y-2">
+      <div className="p-4 space-y-2 flex-1">
         <h3 className="text-lg font-semibold">{property.title || "(ไม่มีชื่อ)"}</h3>
         {property.price && <p className="text-blue-600 font-bold">{property.price}</p>}
         {(property.address || property.city || property.province) && (
@@ -42,15 +42,16 @@ export default function UserPropertyCard({ property, ownerUid }: UserPropertyCar
             </span>
           )}
         </div>
-        <div className="flex gap-2 pt-2">
-          <Link href={`/sell/${ownerUid}/${property.id}`} className="flex-1">
-            <Button variant="outline" className="w-full">
-              ดูรายละเอียด
-            </Button>
-          </Link>
-          <Link href={`/sell/${ownerUid}/${property.id}/edit`} className="flex-1">
-            <Button className="w-full">แก้ไข</Button>
-          </Link>
+        <div className="pt-2">
+          <UserPropertyModal
+            property={property}
+            ownerUid={ownerUid}
+            trigger={
+              <Button variant="outline" className="w-full">
+                ดูรายละเอียด
+              </Button>
+            }
+          />
         </div>
       </div>
     </div>

--- a/components/user-property-card.tsx
+++ b/components/user-property-card.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import Link from "next/link"
+import { Bed, Bath, MapPin } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+interface UserPropertyCardProps {
+  property: any
+  ownerUid: string
+}
+
+export default function UserPropertyCard({ property, ownerUid }: UserPropertyCardProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border shadow-sm bg-white">
+      {Array.isArray(property.photos) && property.photos[0] && (
+        <img
+          src={property.photos[0]}
+          alt={property.title || "property-photo"}
+          className="w-full h-48 object-cover"
+        />
+      )}
+      <div className="p-4 space-y-2">
+        <h3 className="text-lg font-semibold">{property.title || "(ไม่มีชื่อ)"}</h3>
+        {property.price && <p className="text-blue-600 font-bold">{property.price}</p>}
+        {(property.address || property.city || property.province) && (
+          <p className="text-sm text-gray-500 flex items-center">
+            <MapPin className="w-4 h-4 mr-1" />
+            {[property.address, property.city, property.province].filter(Boolean).join(", ")}
+          </p>
+        )}
+        <div className="flex gap-4 text-sm text-gray-600">
+          {property.bedrooms && (
+            <span className="flex items-center">
+              <Bed className="w-4 h-4 mr-1" />
+              {property.bedrooms} นอน
+            </span>
+          )}
+          {property.bathrooms && (
+            <span className="flex items-center">
+              <Bath className="w-4 h-4 mr-1" />
+              {property.bathrooms} น้ำ
+            </span>
+          )}
+        </div>
+        <div className="flex gap-2 pt-2">
+          <Link href={`/sell/${ownerUid}/${property.id}`} className="flex-1">
+            <Button variant="outline" className="w-full">
+              ดูรายละเอียด
+            </Button>
+          </Link>
+          <Link href={`/sell/${ownerUid}/${property.id}/edit`} className="flex-1">
+            <Button className="w-full">แก้ไข</Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/components/user-property-modal.tsx
+++ b/components/user-property-modal.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Bed, Bath, MapPin, Square } from "lucide-react"
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { useAuthContext } from "@/contexts/AuthContext"
+
+interface UserPropertyModalProps {
+  property: any
+  ownerUid: string
+  trigger: React.ReactNode
+}
+
+export default function UserPropertyModal({ property, ownerUid, trigger }: UserPropertyModalProps) {
+  const { user } = useAuthContext()
+  const [activePhoto, setActivePhoto] = useState(0)
+  const photos: string[] = Array.isArray(property.photos) ? property.photos : []
+  const isOwner = user?.uid === ownerUid
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{property.title || "(ไม่มีชื่อ)"}</DialogTitle>
+        </DialogHeader>
+        <div className="grid md:grid-cols-2 gap-6">
+          <div className="space-y-4">
+            {photos.length > 0 ? (
+              <>
+                <img
+                  src={photos[activePhoto]}
+                  alt={property.title || "property-photo"}
+                  className="w-full h-64 md:h-96 object-cover rounded-lg"
+                />
+                {photos.length > 1 && (
+                  <div className="flex gap-2 overflow-x-auto">
+                    {photos.map((url, idx) => (
+                      <img
+                        key={idx}
+                        src={url}
+                        alt={property.title || `thumb-${idx}`}
+                        onClick={() => setActivePhoto(idx)}
+                        className={`w-20 h-20 object-cover rounded cursor-pointer border-2 ${
+                          idx === activePhoto ? "border-blue-500" : "border-transparent"
+                        }`}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="w-full h-64 md:h-96 bg-gray-200 rounded" />
+            )}
+          </div>
+          <div className="space-y-4">
+            {property.price && (
+              <p className="text-xl font-semibold text-blue-600">{property.price}</p>
+            )}
+            {(property.address || property.city || property.province) && (
+              <p className="text-gray-600 flex items-center">
+                <MapPin className="w-4 h-4 mr-1" />
+                {[property.address, property.city, property.province].filter(Boolean).join(", ")}
+              </p>
+            )}
+            <div className="flex flex-wrap gap-4 text-gray-700">
+              {property.bedrooms && (
+                <span className="flex items-center">
+                  <Bed className="w-4 h-4 mr-1" /> {property.bedrooms} ห้องนอน
+                </span>
+              )}
+              {property.bathrooms && (
+                <span className="flex items-center">
+                  <Bath className="w-4 h-4 mr-1" /> {property.bathrooms} ห้องน้ำ
+                </span>
+              )}
+              {property.usableArea && (
+                <span className="flex items-center">
+                  <Square className="w-4 h-4 mr-1" /> พื้นที่ใช้สอย {property.usableArea}
+                </span>
+              )}
+              {property.landArea && (
+                <span className="flex items-center">
+                  <Square className="w-4 h-4 mr-1" /> พื้นที่ดิน {property.landArea}
+                </span>
+              )}
+            </div>
+            {property.description && (
+              <p className="text-gray-700 whitespace-pre-line">{property.description}</p>
+            )}
+            {isOwner && (
+              <Link href={`/sell/${ownerUid}/${property.id}/edit`}>
+                <Button>แก้ไขประกาศ</Button>
+              </Link>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+


### PR DESCRIPTION
## Summary
- display logged-in user's property listings and their images
- add public property detail page with optional edit button for owner
- allow owners to edit basic property info

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (cannot run: requires interactive ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68c7fc9f8da88321bb0315a7322ac653