### PR TITLE
Add property collection entry for sell form submissions

### DIFF
--- a/app/sell/create/page.tsx
+++ b/app/sell/create/page.tsx
@@ -355,6 +355,11 @@ export default function SellCreatePage() {
       )
       const propertyId = docRef.id
 
+      await setDocument("property", propertyId, {
+        ...propertyBase,
+        userId: user.uid,
+      })
+
       const imageData = photos.map((file, idx) => ({
         path: `user/${user.uid}/property/${propertyId}/images/${idx}-${file.name}`,
         file,
@@ -371,10 +376,13 @@ export default function SellCreatePage() {
         videoUrl = await getDownloadURL(videoPath)
       }
 
-      await setDocument(`users/${user.uid}/user_property`, propertyId, {
+      const mediaData = {
         photos: photoUrls,
         video: videoUrl,
-      })
+      }
+
+      await setDocument(`users/${user.uid}/user_property`, propertyId, mediaData)
+      await setDocument("property", propertyId, mediaData)
 
       alert("บันทึกเรียบร้อย!")
     } catch (err) {


### PR DESCRIPTION
## Summary
- write sell form submissions to the shared `property` collection with the submitting user's UID
- keep the property document in sync with uploaded media URLs alongside the existing user subcollection entry

## Testing
- ⚠️ `npm run lint` *(aborted because the command prompts for configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdb125a24832190b738440e9271b1