### PR TITLE
Update buy page cards to use user property data

### DIFF
--- a/app/sell/create/page.tsx
+++ b/app/sell/create/page.tsx
@@ -1,15 +1,21 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import { Inter } from "next/font/google"
-import ChatWidget from "@/components/chat-widget"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Textarea } from "@/components/ui/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Checkbox } from "@/components/ui/checkbox"
-import { Label } from "@/components/ui/label"
+import Link from "next/link";
+import { Inter } from "next/font/google";
+import ChatWidget from "@/components/chat-widget";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import {
   Upload,
   Video,
@@ -24,17 +30,17 @@ import {
   Wifi,
   Flame,
   LocateFixed,
-} from "lucide-react"
+} from "lucide-react";
 
-import { useAuthContext } from "@/contexts/AuthContext"
-import SellAuthPrompt from "@/components/sell-auth-prompt"
+import { useAuthContext } from "@/contexts/AuthContext";
+import SellAuthPrompt from "@/components/sell-auth-prompt";
 
-import { useEffect, useRef, useState, type ChangeEvent } from "react"
-import { Loader } from "@googlemaps/js-api-loader"
-import { uploadFile, uploadFiles, getDownloadURL } from "@/lib/storage"
-import { setDocument, addDocument } from "@/lib/firestore"
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
+import { Loader } from "@googlemaps/js-api-loader";
+import { uploadFile, uploadFiles, getDownloadURL } from "@/lib/storage";
+import { setDocument, addDocument } from "@/lib/firestore";
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"] });
 
 const features = [
   { id: "garden", label: "สวน", icon: TreePine },
@@ -45,284 +51,334 @@ const features = [
   { id: "elevator", label: "ลิฟต์", icon: Square },
   { id: "smart", label: "สมาร์ทโฮม", icon: Wifi },
   { id: "fireplace", label: "เตาผิง", icon: Flame },
-]
+];
 
-type LatLng = { lat: number | null; lng: number | null }
-type Errors = Record<string, string | undefined>
-type Touched = Record<string, boolean>
+type LatLng = { lat: number | null; lng: number | null };
+type Errors = Record<string, string | undefined>;
+type Touched = Record<string, boolean>;
 
 export default function SellCreatePage() {
-  const { user, loading } = useAuthContext()
+  const { user, loading } = useAuthContext();
 
   // ====== Google Maps ======
-  const [mapsReady, setMapsReady] = useState(false)
-  const mapRef = useRef<HTMLDivElement | null>(null)
-  const searchRef = useRef<HTMLInputElement | null>(null)
-  const gmap = useRef<google.maps.Map | null>(null)
-  const marker = useRef<google.maps.Marker | null>(null)
-  const geocoder = useRef<google.maps.Geocoder | null>(null)
-  const autocomplete = useRef<google.maps.places.Autocomplete | null>(null)
-  const photoInputRef = useRef<HTMLInputElement | null>(null)
-  const videoInputRef = useRef<HTMLInputElement | null>(null)
+  const [mapsReady, setMapsReady] = useState(false);
+  const mapRef = useRef<HTMLDivElement | null>(null);
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const gmap = useRef<google.maps.Map | null>(null);
+  const marker = useRef<google.maps.Marker | null>(null);
+  const geocoder = useRef<google.maps.Geocoder | null>(null);
+  const autocomplete = useRef<google.maps.places.Autocomplete | null>(null);
+  const photoInputRef = useRef<HTMLInputElement | null>(null);
+  const videoInputRef = useRef<HTMLInputElement | null>(null);
 
   // ====== Form states ======
   // Seller
-  const [sellerName, setSellerName] = useState("")
-  const [sellerPhone, setSellerPhone] = useState("")
-  const [sellerEmail, setSellerEmail] = useState("")
-  const [sellerRole, setSellerRole] = useState<string>("")
+  const [sellerName, setSellerName] = useState("");
+  const [sellerPhone, setSellerPhone] = useState("");
+  const [sellerEmail, setSellerEmail] = useState("");
+  const [sellerRole, setSellerRole] = useState<string>("");
 
   // Basic
-  const [title, setTitle] = useState("")
-  const [propertyType, setPropertyType] = useState<string>("")
-  const [transactionType, setTransactionType] = useState<string>("")
-  const [price, setPrice] = useState("")
+  const [title, setTitle] = useState("");
+  const [propertyType, setPropertyType] = useState<string>("");
+  const [transactionType, setTransactionType] = useState<string>("");
+  const [price, setPrice] = useState("");
 
   // Location (ผูกกับแผนที่ด้านล่าง)
-  const [address, setAddress] = useState("")
-  const [city, setCity] = useState("")
-  const [province, setProvince] = useState("")
-  const [postal, setPostal] = useState("")
-  const [latlng, setLatlng] = useState<LatLng>({ lat: null, lng: null })
+  const [address, setAddress] = useState("");
+  const [city, setCity] = useState("");
+  const [province, setProvince] = useState("");
+  const [postal, setPostal] = useState("");
+  const [latlng, setLatlng] = useState<LatLng>({ lat: null, lng: null });
 
   // Specs
-  const [landArea, setLandArea] = useState("")
-  const [usableArea, setUsableArea] = useState("")
-  const [bedrooms, setBedrooms] = useState("")
-  const [bathrooms, setBathrooms] = useState("")
-  const [parking, setParking] = useState<string>("")
-  const [yearBuilt, setYearBuilt] = useState("")
+  const [landArea, setLandArea] = useState("");
+  const [usableArea, setUsableArea] = useState("");
+  const [bedrooms, setBedrooms] = useState("");
+  const [bathrooms, setBathrooms] = useState("");
+  const [parking, setParking] = useState<string>("");
+  const [yearBuilt, setYearBuilt] = useState("");
 
   // Description
-  const [description, setDescription] = useState("")
+  const [description, setDescription] = useState("");
 
   // Media
-  const [photos, setPhotos] = useState<File[]>([])
-  const [video, setVideo] = useState<File | null>(null)
-  const [photoPreviews, setPhotoPreviews] = useState<string[]>([])
-  const [videoPreview, setVideoPreview] = useState<string | null>(null)
+  const [photos, setPhotos] = useState<File[]>([]);
+  const [video, setVideo] = useState<File | null>(null);
+  const [photoPreviews, setPhotoPreviews] = useState<string[]>([]);
+  const [videoPreview, setVideoPreview] = useState<string | null>(null);
 
   // Validation UI
-  const [errors, setErrors] = useState<Errors>({})
-  const [touched, setTouched] = useState<Touched>({})
-  const touch = (name: string) => setTouched((t) => ({ ...t, [name]: true }))
+  const [errors, setErrors] = useState<Errors>({});
+  const [touched, setTouched] = useState<Touched>({});
+  const touch = (name: string) => setTouched((t) => ({ ...t, [name]: true }));
 
   const handlePhotosChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? [])
+    const files = Array.from(e.target.files ?? []);
     setPhotos((prev) => {
-      const merged = [...prev, ...files]
-      return merged.slice(0, 50)
-    })
-  }
+      const merged = [...prev, ...files];
+      return merged.slice(0, 50);
+    });
+  };
 
   const handleVideoChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] || null
-    setVideo(file)
-  }
+    const file = e.target.files?.[0] || null;
+    setVideo(file);
+  };
 
   useEffect(() => {
-    const urls = photos.map((file) => URL.createObjectURL(file))
-    setPhotoPreviews(urls)
-    return () => urls.forEach((url) => URL.revokeObjectURL(url))
-  }, [photos])
+    const urls = photos.map((file) => URL.createObjectURL(file));
+    setPhotoPreviews(urls);
+    return () => urls.forEach((url) => URL.revokeObjectURL(url));
+  }, [photos]);
 
   useEffect(() => {
     if (!video) {
-      setVideoPreview(null)
-      return
+      setVideoPreview(null);
+      return;
     }
-    const url = URL.createObjectURL(video)
-    setVideoPreview(url)
-    return () => URL.revokeObjectURL(url)
-  }, [video])
+    const url = URL.createObjectURL(video);
+    setVideoPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [video]);
 
   // ====== Helpers: validation & progress ======
-  const isNonEmpty = (s: string) => s.trim().length > 0
+  const isNonEmpty = (s: string) => s.trim().length > 0;
   const isPositive = (s: string) => {
-    const n = Number(s)
-    return Number.isFinite(n) && n > 0
-  }
-  const emailOk = (s: string) => /\S+@\S+\.\S+/.test(s)
-  const phoneOk = (s: string) => s.replace(/\D/g, "").length >= 6 // เบื้องต้นพอ
+    const n = Number(s);
+    return Number.isFinite(n) && n > 0;
+  };
+  const emailOk = (s: string) => /\S+@\S+\.\S+/.test(s);
+  const phoneOk = (s: string) => s.replace(/\D/g, "").length >= 6; // เบื้องต้นพอ
 
   const validate = (): Errors => {
-    const e: Errors = {}
+    const e: Errors = {};
 
     // Seller
-    if (!isNonEmpty(sellerName)) e.sellerName = "จำเป็น"
-    if (!isNonEmpty(sellerPhone)) e.sellerPhone = "จำเป็น"
-    else if (!phoneOk(sellerPhone)) e.sellerPhone = "เบอร์โทรไม่ถูกต้อง"
-    if (!isNonEmpty(sellerEmail)) e.sellerEmail = "จำเป็น"
-    else if (!emailOk(sellerEmail)) e.sellerEmail = "อีเมลไม่ถูกต้อง"
-    if (!isNonEmpty(sellerRole)) e.sellerRole = "จำเป็น"
+    if (!isNonEmpty(sellerName)) e.sellerName = "จำเป็น";
+    if (!isNonEmpty(sellerPhone)) e.sellerPhone = "จำเป็น";
+    else if (!phoneOk(sellerPhone)) e.sellerPhone = "เบอร์โทรไม่ถูกต้อง";
+    if (!isNonEmpty(sellerEmail)) e.sellerEmail = "จำเป็น";
+    else if (!emailOk(sellerEmail)) e.sellerEmail = "อีเมลไม่ถูกต้อง";
+    if (!isNonEmpty(sellerRole)) e.sellerRole = "จำเป็น";
 
     // Basic
-    if (!isNonEmpty(title)) e.title = "จำเป็น"
-    if (!isNonEmpty(propertyType)) e.propertyType = "จำเป็น"
-    if (!isNonEmpty(transactionType)) e.transactionType = "จำเป็น"
-    if (!isNonEmpty(price)) e.price = "จำเป็น"
-    else if (!isPositive(price)) e.price = "ต้องมากกว่า 0"
+    if (!isNonEmpty(title)) e.title = "จำเป็น";
+    if (!isNonEmpty(propertyType)) e.propertyType = "จำเป็น";
+    if (!isNonEmpty(transactionType)) e.transactionType = "จำเป็น";
+    if (!isNonEmpty(price)) e.price = "จำเป็น";
+    else if (!isPositive(price)) e.price = "ต้องมากกว่า 0";
 
     // Location
-    if (!isNonEmpty(address)) e.address = "จำเป็น"
-    if (!isNonEmpty(city)) e.city = "จำเป็น"
-    if (!isNonEmpty(province)) e.province = "จำเป็น"
-    if (!isNonEmpty(postal)) e.postal = "จำเป็น"
+    if (!isNonEmpty(address)) e.address = "จำเป็น";
+    if (!isNonEmpty(city)) e.city = "จำเป็น";
+    if (!isNonEmpty(province)) e.province = "จำเป็น";
+    if (!isNonEmpty(postal)) e.postal = "จำเป็น";
 
     // Specs
-    if (!isNonEmpty(landArea)) e.landArea = "จำเป็น"
-    else if (!isPositive(landArea)) e.landArea = "ต้องมากกว่า 0"
-    if (!isNonEmpty(usableArea)) e.usableArea = "จำเป็น"
-    else if (!isPositive(usableArea)) e.usableArea = "ต้องมากกว่า 0"
-    if (!isNonEmpty(bedrooms)) e.bedrooms = "จำเป็น"
-    else if (!isPositive(bedrooms)) e.bedrooms = "ต้องมากกว่า 0"
-    if (!isNonEmpty(bathrooms)) e.bathrooms = "จำเป็น"
-    else if (!isPositive(bathrooms)) e.bathrooms = "ต้องมากกว่า 0"
+    if (!isNonEmpty(landArea)) e.landArea = "จำเป็น";
+    else if (!isPositive(landArea)) e.landArea = "ต้องมากกว่า 0";
+    if (!isNonEmpty(usableArea)) e.usableArea = "จำเป็น";
+    else if (!isPositive(usableArea)) e.usableArea = "ต้องมากกว่า 0";
+    if (!isNonEmpty(bedrooms)) e.bedrooms = "จำเป็น";
+    else if (!isPositive(bedrooms)) e.bedrooms = "ต้องมากกว่า 0";
+    if (!isNonEmpty(bathrooms)) e.bathrooms = "จำเป็น";
+    else if (!isPositive(bathrooms)) e.bathrooms = "ต้องมากกว่า 0";
 
     // Description
-    if (!isNonEmpty(description)) e.description = "จำเป็น"
-    else if (description.trim().length < 50) e.description = "ขั้นต่ำ 50 ตัวอักษร"
+    if (!isNonEmpty(description)) e.description = "จำเป็น";
+    else if (description.trim().length < 50)
+      e.description = "ขั้นต่ำ 50 ตัวอักษร";
 
-    return e
-  }
+    return e;
+  };
 
   const requiredFieldKeys = [
-    "sellerName", "sellerPhone", "sellerEmail", "sellerRole",
-    "title", "propertyType", "transactionType", "price",
-    "address", "city", "province", "postal",
-    "landArea", "usableArea", "bedrooms", "bathrooms",
+    "sellerName",
+    "sellerPhone",
+    "sellerEmail",
+    "sellerRole",
+    "title",
+    "propertyType",
+    "transactionType",
+    "price",
+    "address",
+    "city",
+    "province",
+    "postal",
+    "landArea",
+    "usableArea",
+    "bedrooms",
+    "bathrooms",
     "description",
-  ] as const
+  ] as const;
 
   // คิดเปอร์เซ็นต์จาก “จำนวนช่องที่ผ่าน validation”
   const completedCount = (() => {
-    const e = validate()
-    return requiredFieldKeys.length - Object.keys(e).filter(k => (e as any)[k]).length
-  })()
-  const totalRequired = requiredFieldKeys.length
-  const progressPct = Math.round((completedCount / totalRequired) * 100)
+    const e = validate();
+    return (
+      requiredFieldKeys.length -
+      Object.keys(e).filter((k) => (e as any)[k]).length
+    );
+  })();
+  const totalRequired = requiredFieldKeys.length;
+  const progressPct = Math.round((completedCount / totalRequired) * 100);
 
   // ====== Google Maps: load & wire ======
   useEffect(() => {
-    const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
-    if (!key) return
-    const loader = new Loader({ apiKey: key, version: "weekly", libraries: ["places"] })
-    loader.load().then(() => setMapsReady(true)).catch(() => setMapsReady(false))
-  }, [])
+    const key = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+    if (!key) return;
+    const loader = new Loader({
+      apiKey: key,
+      version: "weekly",
+      libraries: ["places"],
+    });
+    loader
+      .load()
+      .then(() => setMapsReady(true))
+      .catch(() => setMapsReady(false));
+  }, []);
 
   useEffect(() => {
-    if (!mapsReady || !mapRef.current) return
-    const start = { lat: 13.7563, lng: 100.5018 } // Bangkok default
+    if (!mapsReady || !mapRef.current) return;
+    const start = { lat: 13.7563, lng: 100.5018 }; // Bangkok default
 
     gmap.current = new google.maps.Map(mapRef.current, {
-      center: start, zoom: 12,
-      mapTypeControl: false, streetViewControl: false, fullscreenControl: true,
-    })
-    marker.current = new google.maps.Marker({ map: gmap.current, position: start, draggable: true })
-    geocoder.current = new google.maps.Geocoder()
+      center: start,
+      zoom: 12,
+      mapTypeControl: false,
+      streetViewControl: false,
+      fullscreenControl: true,
+    });
+    marker.current = new google.maps.Marker({
+      map: gmap.current,
+      position: start,
+      draggable: true,
+    });
+    geocoder.current = new google.maps.Geocoder();
 
     gmap.current.addListener("click", (e: google.maps.MapMouseEvent) => {
-      if (!e.latLng) return
-      placeMarkerAndFill(e.latLng)
-    })
+      if (!e.latLng) return;
+      placeMarkerAndFill(e.latLng);
+    });
     marker.current.addListener("dragend", () => {
-      const pos = marker.current!.getPosition()
-      if (pos) placeMarkerAndFill(pos)
-    })
+      const pos = marker.current!.getPosition();
+      if (pos) placeMarkerAndFill(pos);
+    });
 
     if (searchRef.current) {
-      autocomplete.current = new google.maps.places.Autocomplete(searchRef.current, {
-        fields: ["geometry", "address_components", "formatted_address"],
-        types: ["geocode"],
-      })
-      autocomplete.current.bindTo("bounds", gmap.current)
+      autocomplete.current = new google.maps.places.Autocomplete(
+        searchRef.current,
+        {
+          fields: ["geometry", "address_components", "formatted_address"],
+          types: ["geocode"],
+        },
+      );
+      autocomplete.current.bindTo("bounds", gmap.current);
       autocomplete.current.addListener("place_changed", () => {
-        const place = autocomplete.current!.getPlace()
-        if (!place.geometry || !place.geometry.location) return
-        const loc = place.geometry.location
-        gmap.current!.panTo(loc); gmap.current!.setZoom(16)
-        marker.current!.setPosition(loc)
-        setLatlng({ lat: loc.lat(), lng: loc.lng() })
-        fillAddressFromComponents(place.address_components ?? [], place.formatted_address)
-      })
+        const place = autocomplete.current!.getPlace();
+        if (!place.geometry || !place.geometry.location) return;
+        const loc = place.geometry.location;
+        gmap.current!.panTo(loc);
+        gmap.current!.setZoom(16);
+        marker.current!.setPosition(loc);
+        setLatlng({ lat: loc.lat(), lng: loc.lng() });
+        fillAddressFromComponents(
+          place.address_components ?? [],
+          place.formatted_address,
+        );
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapsReady])
+  }, [mapsReady]);
 
   const centerOnUser = () => {
     if (!navigator.geolocation) {
-      alert("เบราว์เซอร์ของคุณไม่รองรับการระบุตำแหน่ง")
-      return
+      alert("เบราว์เซอร์ของคุณไม่รองรับการระบุตำแหน่ง");
+      return;
     }
     navigator.geolocation.getCurrentPosition(
       ({ coords }) => {
-        if (!gmap.current) return
-        const loc = new google.maps.LatLng(coords.latitude, coords.longitude)
-        gmap.current.setZoom(16)
-        placeMarkerAndFill(loc)
+        if (!gmap.current) return;
+        const loc = new google.maps.LatLng(coords.latitude, coords.longitude);
+        gmap.current.setZoom(16);
+        placeMarkerAndFill(loc);
       },
-      () => console.error("ไม่สามารถรับตำแหน่งของคุณได้")
-    )
-  }
+      () => console.error("ไม่สามารถรับตำแหน่งของคุณได้"),
+    );
+  };
 
   const placeMarkerAndFill = (pos: google.maps.LatLng) => {
-    marker.current!.setPosition(pos)
-    gmap.current!.panTo(pos)
-    setLatlng({ lat: pos.lat(), lng: pos.lng() })
-    if (!geocoder.current) return
+    marker.current!.setPosition(pos);
+    gmap.current!.panTo(pos);
+    setLatlng({ lat: pos.lat(), lng: pos.lng() });
+    if (!geocoder.current) return;
     geocoder.current.geocode({ location: pos }, (results, status) => {
       if (status === "OK" && results && results[0]) {
-        fillAddressFromComponents(results[0].address_components ?? [], results[0].formatted_address)
-        if (searchRef.current) searchRef.current.value = results[0].formatted_address ?? ""
+        fillAddressFromComponents(
+          results[0].address_components ?? [],
+          results[0].formatted_address,
+        );
+        if (searchRef.current)
+          searchRef.current.value = results[0].formatted_address ?? "";
       }
-    })
-  }
+    });
+  };
 
   const fillAddressFromComponents = (
     components: google.maps.GeocoderAddressComponent[],
-    formatted?: string
+    formatted?: string,
   ) => {
-    const get = (type: string) => components.find(c => c.types.includes(type))?.long_name ?? ""
-    const streetNumber = get("street_number")
-    const route = get("route")
-    const sublocality = get("sublocality") || get("sublocality_level_1")
-    const locality = get("locality") || get("administrative_area_level_2")
-    const admin1 = get("administrative_area_level_1")
-    const zip = get("postal_code")
+    const get = (type: string) =>
+      components.find((c) => c.types.includes(type))?.long_name ?? "";
+    const streetNumber = get("street_number");
+    const route = get("route");
+    const sublocality = get("sublocality") || get("sublocality_level_1");
+    const locality = get("locality") || get("administrative_area_level_2");
+    const admin1 = get("administrative_area_level_1");
+    const zip = get("postal_code");
 
-    const addr = [streetNumber, route].filter(Boolean).join(" ")
-      || [route, sublocality].filter(Boolean).join(", ")
-      || formatted || ""
+    const addr =
+      [streetNumber, route].filter(Boolean).join(" ") ||
+      [route, sublocality].filter(Boolean).join(", ") ||
+      formatted ||
+      "";
 
-    setAddress(addr); touch("address")
-    setCity(locality || sublocality || ""); touch("city")
-    setProvince(admin1 || ""); touch("province")
-    setPostal(zip || ""); touch("postal")
-  }
+    setAddress(addr);
+    touch("address");
+    setCity(locality || sublocality || "");
+    touch("city");
+    setProvince(admin1 || "");
+    touch("province");
+    setPostal(zip || "");
+    touch("postal");
+  };
 
   // ====== Submit ======
   const handleSubmit = async () => {
-    const e = validate()
-    setErrors(e)
+    const e = validate();
+    setErrors(e);
     // mark all as touched toโชว์ error
-    const t: Touched = {}
-    requiredFieldKeys.forEach((k) => (t[k] = true))
-    setTouched((old) => ({ ...old, ...t }))
+    const t: Touched = {};
+    requiredFieldKeys.forEach((k) => (t[k] = true));
+    setTouched((old) => ({ ...old, ...t }));
 
-    const firstErrorKey = requiredFieldKeys.find((k) => e[k])
+    const firstErrorKey = requiredFieldKeys.find((k) => e[k]);
     if (firstErrorKey) {
-      const el = document.getElementById(firstErrorKey)
-      if (el?.scrollIntoView) el.scrollIntoView({ behavior: "smooth", block: "center" })
-      return
+      const el = document.getElementById(firstErrorKey);
+      if (el?.scrollIntoView)
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
     }
 
-    if (!user) return
+    if (!user) return;
 
     try {
       // Ensure parent user document exists so subcollection can be created
-      await setDocument("users", user.uid, { uid: user.uid })
+      await setDocument("users", user.uid, { uid: user.uid });
 
       const propertyBase = {
+        userUid: user.uid,
         sellerName,
         sellerPhone,
         sellerEmail,
@@ -347,55 +403,56 @@ export default function SellCreatePage() {
         photos: [] as string[],
         video: null as string | null,
         createdAt: new Date().toISOString(),
-      }
+      };
 
       const docRef = await addDocument(
         `users/${user.uid}/user_property`,
         propertyBase,
-      )
-      const propertyId = docRef.id
+      );
+      const propertyId = docRef.id;
 
       const imageData = photos.map((file, idx) => ({
         path: `user/${user.uid}/property/${propertyId}/images/${idx}-${file.name}`,
         file,
-      }))
-      await uploadFiles(imageData)
+      }));
+      await uploadFiles(imageData);
       const photoUrls = await Promise.all(
-        imageData.map(({ path }) => getDownloadURL(path))
-      )
+        imageData.map(({ path }) => getDownloadURL(path)),
+      );
 
-      let videoUrl: string | null = null
+      let videoUrl: string | null = null;
       if (video) {
-        const videoPath = `user/${user.uid}/property/${propertyId}/videos/${video.name}`
-        await uploadFile(videoPath, video)
-        videoUrl = await getDownloadURL(videoPath)
+        const videoPath = `user/${user.uid}/property/${propertyId}/videos/${video.name}`;
+        await uploadFile(videoPath, video);
+        videoUrl = await getDownloadURL(videoPath);
       }
 
       await setDocument(`users/${user.uid}/user_property`, propertyId, {
         photos: photoUrls,
         video: videoUrl,
-      })
+      });
 
       await setDocument("property", propertyId, {
-  ...propertyBase,          // ข้อมูลพื้นฐานเดิม
-  userUid: user.uid,        // ชี้ว่าเป็นทรัพย์ของ user ไหน
-  photos: photoUrls,        // รูปที่อัปโหลดแล้ว
-  video: videoUrl,          // วิดีโอที่อัปโหลดแล้ว (ถ้ามี)
-})
+        ...propertyBase, // ข้อมูลพื้นฐานเดิม
+        userUid: user.uid, // ชี้ว่าเป็นทรัพย์ของ user ไหน
+        photos: photoUrls, // รูปที่อัปโหลดแล้ว
+        video: videoUrl, // วิดีโอที่อัปโหลดแล้ว (ถ้ามี)
+      });
 
-      alert("บันทึกเรียบร้อย!")
+      alert("บันทึกเรียบร้อย!");
     } catch (err) {
-      console.error(err)
-      alert("เกิดข้อผิดพลาดในการบันทึก")
+      console.error(err);
+      alert("เกิดข้อผิดพลาดในการบันทึก");
     }
-  }
+  };
 
   // convenience: แสดงข้อความผิดพลาดเมื่อ touched + error
-  const showErr = (key: string) => touched[key] && errors[key]
-  const inputErrClass = (key: string) => (showErr(key) ? "border-red-500 focus-visible:ring-red-500" : "")
+  const showErr = (key: string) => touched[key] && errors[key];
+  const inputErrClass = (key: string) =>
+    showErr(key) ? "border-red-500 focus-visible:ring-red-500" : "";
 
-  if (loading) return null
-  if (!user) return <SellAuthPrompt />
+  if (loading) return null;
+  if (!user) return <SellAuthPrompt />;
 
   return (
     <div className={`${inter.className} bg-gray-50 min-h-screen`}>
@@ -425,7 +482,9 @@ export default function SellCreatePage() {
 
         {/* Seller Information */}
         <Card>
-          <CardHeader><CardTitle>ข้อมูลผู้ขาย</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>ข้อมูลผู้ขาย</CardTitle>
+          </CardHeader>
           <CardContent className="grid gap-4 sm:grid-cols-2">
             <div>
               <Label htmlFor="sellerName">ชื่อ-นามสกุล*</Label>
@@ -438,7 +497,9 @@ export default function SellCreatePage() {
                 placeholder="กรอกชื่อ-นามสกุล"
                 aria-invalid={!!showErr("sellerName")}
               />
-              {showErr("sellerName") && <p className="text-xs text-red-600 mt-1">{errors.sellerName}</p>}
+              {showErr("sellerName") && (
+                <p className="text-xs text-red-600 mt-1">{errors.sellerName}</p>
+              )}
             </div>
             <div>
               <Label htmlFor="sellerPhone">เบอร์โทร*</Label>
@@ -451,7 +512,11 @@ export default function SellCreatePage() {
                 placeholder="081 234 5678"
                 aria-invalid={!!showErr("sellerPhone")}
               />
-              {showErr("sellerPhone") && <p className="text-xs text-red-600 mt-1">{errors.sellerPhone}</p>}
+              {showErr("sellerPhone") && (
+                <p className="text-xs text-red-600 mt-1">
+                  {errors.sellerPhone}
+                </p>
+              )}
             </div>
             <div>
               <Label htmlFor="sellerEmail">อีเมล*</Label>
@@ -464,15 +529,25 @@ export default function SellCreatePage() {
                 placeholder="you@example.com"
                 aria-invalid={!!showErr("sellerEmail")}
               />
-              {showErr("sellerEmail") && <p className="text-xs text-red-600 mt-1">{errors.sellerEmail}</p>}
+              {showErr("sellerEmail") && (
+                <p className="text-xs text-red-600 mt-1">
+                  {errors.sellerEmail}
+                </p>
+              )}
             </div>
             <div>
               <Label htmlFor="sellerRole">บทบาท*</Label>
               <Select
                 value={sellerRole}
-                onValueChange={(v) => { setSellerRole(v); touch("sellerRole") }}
+                onValueChange={(v) => {
+                  setSellerRole(v);
+                  touch("sellerRole");
+                }}
               >
-                <SelectTrigger id="sellerRole" className={inputErrClass("sellerRole")}> 
+                <SelectTrigger
+                  id="sellerRole"
+                  className={inputErrClass("sellerRole")}
+                >
                   <SelectValue placeholder="เลือกบทบาทของคุณ" />
                 </SelectTrigger>
                 <SelectContent>
@@ -480,14 +555,18 @@ export default function SellCreatePage() {
                   <SelectItem value="agent">นายหน้า</SelectItem>
                 </SelectContent>
               </Select>
-              {showErr("sellerRole") && <p className="text-xs text-red-600 mt-1">{errors.sellerRole}</p>}
+              {showErr("sellerRole") && (
+                <p className="text-xs text-red-600 mt-1">{errors.sellerRole}</p>
+              )}
             </div>
           </CardContent>
         </Card>
 
         {/* Property Basic Details */}
         <Card>
-          <CardHeader><CardTitle>รายละเอียดพื้นฐานของทรัพย์</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>รายละเอียดพื้นฐานของทรัพย์</CardTitle>
+          </CardHeader>
           <CardContent className="grid gap-4 sm:grid-cols-2">
             <div className="sm:col-span-2">
               <Label htmlFor="title">ชื่อประกาศ*</Label>
@@ -500,15 +579,23 @@ export default function SellCreatePage() {
                 placeholder="เช่น บ้านสองชั้นสมัยใหม่ใจกลางเมือง"
                 aria-invalid={!!showErr("title")}
               />
-              {showErr("title") && <p className="text-xs text-red-600 mt-1">{errors.title}</p>}
+              {showErr("title") && (
+                <p className="text-xs text-red-600 mt-1">{errors.title}</p>
+              )}
             </div>
             <div>
               <Label htmlFor="propertyType">ประเภททรัพย์สิน*</Label>
               <Select
                 value={propertyType}
-                onValueChange={(v) => { setPropertyType(v); touch("propertyType") }}
+                onValueChange={(v) => {
+                  setPropertyType(v);
+                  touch("propertyType");
+                }}
               >
-                <SelectTrigger id="propertyType" className={inputErrClass("propertyType")}> 
+                <SelectTrigger
+                  id="propertyType"
+                  className={inputErrClass("propertyType")}
+                >
                   <SelectValue placeholder="เลือกประเภท" />
                 </SelectTrigger>
                 <SelectContent>
@@ -517,15 +604,25 @@ export default function SellCreatePage() {
                   <SelectItem value="land">ที่ดิน</SelectItem>
                 </SelectContent>
               </Select>
-              {showErr("propertyType") && <p className="text-xs text-red-600 mt-1">{errors.propertyType}</p>}
+              {showErr("propertyType") && (
+                <p className="text-xs text-red-600 mt-1">
+                  {errors.propertyType}
+                </p>
+              )}
             </div>
             <div>
               <Label htmlFor="transactionType">ประเภทการทำธุรกรรม*</Label>
               <Select
                 value={transactionType}
-                onValueChange={(v) => { setTransactionType(v); touch("transactionType") }}
+                onValueChange={(v) => {
+                  setTransactionType(v);
+                  touch("transactionType");
+                }}
               >
-                <SelectTrigger id="transactionType" className={inputErrClass("transactionType")}> 
+                <SelectTrigger
+                  id="transactionType"
+                  className={inputErrClass("transactionType")}
+                >
                   <SelectValue placeholder="เลือกประเภท" />
                 </SelectTrigger>
                 <SelectContent>
@@ -533,7 +630,11 @@ export default function SellCreatePage() {
                   <SelectItem value="rent">เช่า</SelectItem>
                 </SelectContent>
               </Select>
-              {showErr("transactionType") && <p className="text-xs text-red-600 mt-1">{errors.transactionType}</p>}
+              {showErr("transactionType") && (
+                <p className="text-xs text-red-600 mt-1">
+                  {errors.transactionType}
+                </p>
+              )}
             </div>
             <div>
               <Label htmlFor="price">ราคา*</Label>
@@ -547,14 +648,18 @@ export default function SellCreatePage() {
                 placeholder="฿ 750,000"
                 aria-invalid={!!showErr("price")}
               />
-              {showErr("price") && <p className="text-xs text-red-600 mt-1">{errors.price}</p>}
+              {showErr("price") && (
+                <p className="text-xs text-red-600 mt-1">{errors.price}</p>
+              )}
             </div>
           </CardContent>
         </Card>
 
         {/* Property Location */}
         <Card>
-          <CardHeader><CardTitle>ที่ตั้งทรัพย์สิน</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>ที่ตั้งทรัพย์สิน</CardTitle>
+          </CardHeader>
           <CardContent className="space-y-4">
             <div>
               <Label htmlFor="map-search">ค้นหาบนแผนที่</Label>
@@ -587,7 +692,9 @@ export default function SellCreatePage() {
                   placeholder="123 ถนนโอ๊ค"
                   aria-invalid={!!showErr("address")}
                 />
-                {showErr("address") && <p className="text-xs text-red-600 mt-1">{errors.address}</p>}
+                {showErr("address") && (
+                  <p className="text-xs text-red-600 mt-1">{errors.address}</p>
+                )}
               </div>
               <div>
                 <Label htmlFor="city">เขต/อำเภอ*</Label>
@@ -600,7 +707,9 @@ export default function SellCreatePage() {
                   placeholder="เขตปทุมวัน"
                   aria-invalid={!!showErr("city")}
                 />
-                {showErr("city") && <p className="text-xs text-red-600 mt-1">{errors.city}</p>}
+                {showErr("city") && (
+                  <p className="text-xs text-red-600 mt-1">{errors.city}</p>
+                )}
               </div>
               <div>
                 <Label htmlFor="province">จังหวัด*</Label>
@@ -613,7 +722,9 @@ export default function SellCreatePage() {
                   placeholder="กรุงเทพมหานคร"
                   aria-invalid={!!showErr("province")}
                 />
-                {showErr("province") && <p className="text-xs text-red-600 mt-1">{errors.province}</p>}
+                {showErr("province") && (
+                  <p className="text-xs text-red-600 mt-1">{errors.province}</p>
+                )}
               </div>
               <div>
                 <Label htmlFor="postal">รหัสไปรษณีย์*</Label>
@@ -626,7 +737,9 @@ export default function SellCreatePage() {
                   placeholder="10110"
                   aria-invalid={!!showErr("postal")}
                 />
-                {showErr("postal") && <p className="text-xs text-red-600 mt-1">{errors.postal}</p>}
+                {showErr("postal") && (
+                  <p className="text-xs text-red-600 mt-1">{errors.postal}</p>
+                )}
               </div>
             </div>
 
@@ -645,7 +758,9 @@ export default function SellCreatePage() {
 
         {/* Property Specifications */}
         <Card>
-          <CardHeader><CardTitle>สเปกของทรัพย์</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>สเปกของทรัพย์</CardTitle>
+          </CardHeader>
           <CardContent className="grid gap-4 sm:grid-cols-2">
             <div>
               <Label htmlFor="landArea">พื้นที่ดิน*</Label>
@@ -658,7 +773,9 @@ export default function SellCreatePage() {
                 placeholder="2400"
                 aria-invalid={!!showErr("landArea")}
               />
-              {showErr("landArea") && <p className="text-xs text-red-600 mt-1">{errors.landArea}</p>}
+              {showErr("landArea") && (
+                <p className="text-xs text-red-600 mt-1">{errors.landArea}</p>
+              )}
             </div>
             <div>
               <Label htmlFor="usableArea">พื้นที่ใช้สอย*</Label>
@@ -671,7 +788,9 @@ export default function SellCreatePage() {
                 placeholder="1800"
                 aria-invalid={!!showErr("usableArea")}
               />
-              {showErr("usableArea") && <p className="text-xs text-red-600 mt-1">{errors.usableArea}</p>}
+              {showErr("usableArea") && (
+                <p className="text-xs text-red-600 mt-1">{errors.usableArea}</p>
+              )}
             </div>
             <div>
               <Label htmlFor="bedrooms">ห้องนอน*</Label>
@@ -684,7 +803,9 @@ export default function SellCreatePage() {
                 placeholder="3"
                 aria-invalid={!!showErr("bedrooms")}
               />
-              {showErr("bedrooms") && <p className="text-xs text-red-600 mt-1">{errors.bedrooms}</p>}
+              {showErr("bedrooms") && (
+                <p className="text-xs text-red-600 mt-1">{errors.bedrooms}</p>
+              )}
             </div>
             <div>
               <Label htmlFor="bathrooms">ห้องน้ำ*</Label>
@@ -697,7 +818,9 @@ export default function SellCreatePage() {
                 placeholder="2"
                 aria-invalid={!!showErr("bathrooms")}
               />
-              {showErr("bathrooms") && <p className="text-xs text-red-600 mt-1">{errors.bathrooms}</p>}
+              {showErr("bathrooms") && (
+                <p className="text-xs text-red-600 mt-1">{errors.bathrooms}</p>
+              )}
             </div>
             <div>
               <Label htmlFor="parking">ที่จอดรถ</Label>
@@ -727,7 +850,9 @@ export default function SellCreatePage() {
 
         {/* Property Description */}
         <Card>
-          <CardHeader><CardTitle>รายละเอียดเพิ่มเติม</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>รายละเอียดเพิ่มเติม</CardTitle>
+          </CardHeader>
           <CardContent className="space-y-2">
             <Label htmlFor="description">บรรยายทรัพย์สินของคุณ*</Label>
             <Textarea
@@ -740,19 +865,28 @@ export default function SellCreatePage() {
               rows={5}
               aria-invalid={!!showErr("description")}
             />
-            {showErr("description") && <p className="text-xs text-red-600">{errors.description}</p>}
-            <p className="text-xs text-gray-500">ขั้นต่ำ 50 ตัวอักษร โปรดบรรยายเพื่อดึงดูดผู้ซื้อ</p>
+            {showErr("description") && (
+              <p className="text-xs text-red-600">{errors.description}</p>
+            )}
+            <p className="text-xs text-gray-500">
+              ขั้นต่ำ 50 ตัวอักษร โปรดบรรยายเพื่อดึงดูดผู้ซื้อ
+            </p>
           </CardContent>
         </Card>
 
         {/* Property Photos */}
         <Card>
-          <CardHeader><CardTitle>รูปภาพทรัพย์ (สูงสุด 50 รูป)</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>รูปภาพทรัพย์ (สูงสุด 50 รูป)</CardTitle>
+          </CardHeader>
           <CardContent className="space-y-6">
             <div className="border-2 border-dashed rounded-lg p-8 text-center">
               <Camera className="mx-auto h-10 w-10 text-gray-400 mb-4" />
               <p className="text-sm text-gray-500 mb-4">ลากและวางรูปที่นี่</p>
-              <Button onClick={() => photoInputRef.current?.click()}><Upload className="mr-2 h-4 w-4" />เลือกภาพ</Button>
+              <Button onClick={() => photoInputRef.current?.click()}>
+                <Upload className="mr-2 h-4 w-4" />
+                เลือกภาพ
+              </Button>
               <input
                 ref={photoInputRef}
                 type="file"
@@ -763,20 +897,37 @@ export default function SellCreatePage() {
               />
               {photoPreviews.length > 0 && (
                 <>
-                  <p className="text-xs text-gray-500 mt-4">เลือกแล้ว {photos.length} รูป</p>
+                  <p className="text-xs text-gray-500 mt-4">
+                    เลือกแล้ว {photos.length} รูป
+                  </p>
                   <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 mt-4">
                     {photoPreviews.map((src, idx) => (
-                      <img key={idx} src={src} alt={`preview-${idx}`} className="h-24 w-full object-cover rounded" />
+                      <img
+                        key={idx}
+                        src={src}
+                        alt={`preview-${idx}`}
+                        className="h-24 w-full object-cover rounded"
+                      />
                     ))}
                   </div>
                 </>
               )}
-              <p className="text-xs text-gray-500 mt-4">รองรับ JPG, PNG, GIF ขนาดไม่เกิน 10MB ต่อไฟล์</p>
+              <p className="text-xs text-gray-500 mt-4">
+                รองรับ JPG, PNG, GIF ขนาดไม่เกิน 10MB ต่อไฟล์
+              </p>
             </div>
             <div className="border-2 border-dashed rounded-lg p-8 text-center">
               <Video className="mx-auto h-10 w-10 text-gray-400 mb-4" />
-              <p className="text-sm text-gray-500 mb-4">อัปโหลดวิดีโอหรือทัวร์เสมือน</p>
-              <Button variant="outline" onClick={() => videoInputRef.current?.click()}><Upload className="mr-2 h-4 w-4" />เลือกวิดีโอ</Button>
+              <p className="text-sm text-gray-500 mb-4">
+                อัปโหลดวิดีโอหรือทัวร์เสมือน
+              </p>
+              <Button
+                variant="outline"
+                onClick={() => videoInputRef.current?.click()}
+              >
+                <Upload className="mr-2 h-4 w-4" />
+                เลือกวิดีโอ
+              </Button>
               <input
                 ref={videoInputRef}
                 type="file"
@@ -784,27 +935,37 @@ export default function SellCreatePage() {
                 className="hidden"
                 onChange={handleVideoChange}
               />
-              {video && <p className="text-xs text-gray-500 mt-4">{video.name}</p>}
+              {video && (
+                <p className="text-xs text-gray-500 mt-4">{video.name}</p>
+              )}
               {videoPreview && (
                 <video controls className="mt-4 w-full max-h-64">
                   <source src={videoPreview} type={video?.type} />
                 </video>
               )}
-              <p className="text-xs text-gray-500 mt-4">สูงสุด 100MB รองรับ MP4, MOV</p>
+              <p className="text-xs text-gray-500 mt-4">
+                สูงสุด 100MB รองรับ MP4, MOV
+              </p>
             </div>
           </CardContent>
         </Card>
 
         {/* Additional Options */}
         <Card>
-          <CardHeader><CardTitle>ตัวเลือกเพิ่มเติม</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>ตัวเลือกเพิ่มเติม</CardTitle>
+          </CardHeader>
           <CardContent className="space-y-4">
             <div className="flex items-start justify-between">
               <div className="flex items-start space-x-2">
                 <Checkbox id="mortgage" />
                 <div className="space-y-1">
-                  <Label htmlFor="mortgage" className="font-medium">เพิ่มเครื่องคำนวณสินเชื่อ</Label>
-                  <p className="text-sm text-gray-500">ช่วยผู้ซื้อประมาณค่างวดรายเดือน</p>
+                  <Label htmlFor="mortgage" className="font-medium">
+                    เพิ่มเครื่องคำนวณสินเชื่อ
+                  </Label>
+                  <p className="text-sm text-gray-500">
+                    ช่วยผู้ซื้อประมาณค่างวดรายเดือน
+                  </p>
                 </div>
               </div>
               <span className="text-sm text-gray-500">ฟรี</span>
@@ -813,8 +974,12 @@ export default function SellCreatePage() {
               <div className="flex items-start space-x-2">
                 <Checkbox id="featured" />
                 <div className="space-y-1">
-                  <Label htmlFor="featured" className="font-medium">ประกาศเด่น</Label>
-                  <p className="text-sm text-gray-500">โดดเด่นด้วยตำแหน่งพรีเมียม</p>
+                  <Label htmlFor="featured" className="font-medium">
+                    ประกาศเด่น
+                  </Label>
+                  <p className="text-sm text-gray-500">
+                    โดดเด่นด้วยตำแหน่งพรีเมียม
+                  </p>
                 </div>
               </div>
               <span className="text-sm text-gray-500">25 ดอลลาร์/เดือน</span>
@@ -826,12 +991,15 @@ export default function SellCreatePage() {
         <div className="flex flex-col sm:flex-row gap-4 justify-end">
           <Button variant="outline">ดูตัวอย่างประกาศ</Button>
           <Button variant="secondary">บันทึกร่าง</Button>
-          <Button onClick={handleSubmit} className="bg-purple-600 text-white hover:bg-purple-700">
+          <Button
+            onClick={handleSubmit}
+            className="bg-purple-600 text-white hover:bg-purple-700"
+          >
             ลงประกาศ
           </Button>
         </div>
       </div>
       <ChatWidget />
     </div>
-  )
+  );
 }

--- a/app/sell/page.tsx
+++ b/app/sell/page.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link"
 import { useEffect, useState } from "react"
-import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore"
 
 import ChatWidget from "@/components/chat-widget"
 import { UserPropertyCard } from "@/components/user-property-card"
@@ -12,99 +11,8 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useAuthContext } from "@/contexts/AuthContext"
 import { subscribeToCollection } from "@/lib/firestore"
+import { mapDocumentToUserProperty, parseUserPropertyCreatedAt } from "@/lib/user-property-mapper"
 import type { UserProperty } from "@/types/user-property"
-
-const toStringValue = (value: unknown): string => {
-  if (typeof value === "string") return value
-  if (typeof value === "number" && Number.isFinite(value)) return value.toString()
-  return ""
-}
-
-const toOptionalString = (value: unknown): string | null => {
-  if (typeof value === "string") return value || null
-  if (typeof value === "number" && Number.isFinite(value)) return value.toString()
-  return null
-}
-
-const toNumberOrNull = (value: unknown): number | null => {
-  if (typeof value === "number" && Number.isFinite(value)) return value
-  if (typeof value === "string") {
-    const parsed = Number(value)
-    return Number.isFinite(parsed) ? parsed : null
-  }
-  return null
-}
-
-const toNumberOrZero = (value: unknown): number => {
-  if (typeof value === "number" && Number.isFinite(value)) return value
-  if (typeof value === "string") {
-    const parsed = Number(value)
-    if (Number.isFinite(parsed)) return parsed
-  }
-  return 0
-}
-
-const toIsoString = (value: unknown): string => {
-  if (typeof value === "string") return value
-  if (
-    value &&
-    typeof value === "object" &&
-    "toDate" in value &&
-    typeof (value as { toDate?: () => Date }).toDate === "function"
-  ) {
-    const date = (value as { toDate: () => Date }).toDate()
-    if (date instanceof Date && !Number.isNaN(date.getTime())) {
-      return date.toISOString()
-    }
-  }
-  return ""
-}
-
-const parseCreatedAt = (createdAt: string): number => {
-  if (!createdAt) return 0
-  const time = Date.parse(createdAt)
-  return Number.isNaN(time) ? 0 : time
-}
-
-const mapDocumentToProperty = (
-  doc: QueryDocumentSnapshot<DocumentData>,
-): UserProperty => {
-  const data = doc.data()
-  const photos = Array.isArray(data.photos)
-    ? data.photos.filter((item: unknown): item is string => typeof item === "string")
-    : []
-
-  return {
-    id: doc.id,
-    sellerName: toStringValue(data.sellerName),
-    sellerPhone: toStringValue(data.sellerPhone),
-    sellerEmail: toStringValue(data.sellerEmail),
-    sellerRole: toStringValue(data.sellerRole),
-    title: toStringValue(data.title),
-    propertyType: toStringValue(data.propertyType),
-    transactionType: toStringValue(data.transactionType),
-    price: toNumberOrZero(data.price),
-    address: toStringValue(data.address),
-    city: toStringValue(data.city),
-    province: toStringValue(data.province),
-    postal: toStringValue(data.postal),
-    lat: toNumberOrNull(data.lat),
-    lng: toNumberOrNull(data.lng),
-    landArea: toStringValue(data.landArea),
-    usableArea: toStringValue(data.usableArea),
-    bedrooms: toStringValue(data.bedrooms),
-    bathrooms: toStringValue(data.bathrooms),
-    parking: toOptionalString(data.parking),
-    yearBuilt: toOptionalString(data.yearBuilt),
-    description: toStringValue(data.description),
-    photos,
-    video:
-      typeof data.video === "string" && data.video.trim().length > 0
-        ? data.video
-        : null,
-    createdAt: toIsoString(data.createdAt),
-  }
-}
 
 export default function SellDashboardPage() {
   const { user, loading } = useAuthContext()
@@ -138,9 +46,11 @@ export default function SellDashboardPage() {
           `users/${user.uid}/user_property`,
           (docs) => {
             if (!isActive) return
-            const mapped = docs.map(mapDocumentToProperty)
+            const mapped = docs.map(mapDocumentToUserProperty)
             mapped.sort(
-              (a, b) => parseCreatedAt(b.createdAt) - parseCreatedAt(a.createdAt),
+              (a, b) =>
+                parseUserPropertyCreatedAt(b.createdAt) -
+                parseUserPropertyCreatedAt(a.createdAt),
             )
             setProperties(mapped)
             setPropertiesLoading(false)

--- a/app/users/[uid]/page.tsx
+++ b/app/users/[uid]/page.tsx
@@ -1,0 +1,9 @@
+import { UserProfilePage } from "@/components/user-profile-page";
+
+interface UserProfileRouteProps {
+  params: { uid: string };
+}
+
+export default function UserProfileRoute({ params }: UserProfileRouteProps) {
+  return <UserProfilePage uid={params.uid} />;
+}

--- a/components/featured-properties.tsx
+++ b/components/featured-properties.tsx
@@ -1,72 +1,75 @@
 "use client"
 
-import { useState } from "react"
-import PropertyCard from "./property-card"
-import PropertyModal from "./property-modal"
+import { useMemo, useState } from "react"
 
-const featuredProperties = [
-  {
-    id: 1,
-    title: "บ้านครอบครัวสมัยใหม่",
-    price: "$450,000",
-    location: "123 ถนนโอ๊ค ใจกลางเมือง",
-    beds: 3,
-    baths: 2,
-    sqft: 1200,
-    type: "sale" as const,
-    gradient: "bg-gradient-to-r from-blue-400 to-purple-500",
-  },
-  {
-    id: 2,
-    title: "อพาร์ตเมนต์หรู",
-    price: "$2,500/mo",
-    location: "456 ถนนไพน์ ย่านมิดทาวน์",
-    beds: 2,
-    baths: 2,
-    sqft: 950,
-    type: "rent" as const,
-    gradient: "bg-gradient-to-r from-green-400 to-blue-500",
-  },
-  {
-    id: 3,
-    title: "คอทเทจอบอุ่น",
-    price: "$320,000",
-    location: "789 ถนนเมเปิล ชานเมือง",
-    beds: 2,
-    baths: 1,
-    sqft: 800,
-    type: "sale" as const,
-    gradient: "bg-gradient-to-r from-purple-400 to-pink-500",
-  },
-]
+import { useAllUserProperties } from "@/hooks/use-all-user-properties"
+import type { UserProperty } from "@/types/user-property"
+
+import { UserPropertyCard } from "./user-property-card"
+import { UserPropertyModal } from "./user-property-modal"
 
 export default function FeaturedProperties() {
-  const [selectedProperty, setSelectedProperty] = useState<number | null>(null)
+  const { properties, loading, error } = useAllUserProperties()
+  const [selectedProperty, setSelectedProperty] = useState<UserProperty | null>(null)
 
-  const handleViewDetails = (id: number) => {
-    setSelectedProperty(id)
+  const featuredProperties = useMemo(() => properties.slice(0, 3), [properties])
+
+  const handleViewDetails = (property: UserProperty) => {
+    setSelectedProperty(property)
   }
 
-  const handleCloseModal = () => {
-    setSelectedProperty(null)
+  const handleModalChange = (open: boolean) => {
+    if (!open) {
+      setSelectedProperty(null)
+    }
   }
 
   return (
     <section className="py-16">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-800 mb-4">อสังหาริมทรัพย์แนะนำ</h2>
-          <p className="text-gray-600 text-lg">คัดสรรอสังหาริมทรัพย์พิเศษเพื่อคุณ</p>
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mb-12 text-center">
+          <h2 className="mb-4 text-3xl font-bold text-gray-800 md:text-4xl">อสังหาริมทรัพย์แนะนำ</h2>
+          <p className="text-lg text-gray-600">คัดสรรอสังหาริมทรัพย์พิเศษเพื่อคุณ</p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {featuredProperties.map((property) => (
-            <PropertyCard key={property.id} {...property} onViewDetails={handleViewDetails} />
-          ))}
-        </div>
+        {loading ? (
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={index}
+                className="flex h-full flex-col overflow-hidden rounded-2xl border bg-white p-4 shadow-sm animate-pulse"
+              >
+                <div className="mb-4 h-40 w-full rounded-xl bg-gray-200" />
+                <div className="space-y-3">
+                  <div className="h-4 w-3/4 rounded bg-gray-200" />
+                  <div className="h-4 w-1/2 rounded bg-gray-200" />
+                  <div className="h-4 w-full rounded bg-gray-200" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <p className="text-center text-sm text-red-600">{error}</p>
+        ) : featuredProperties.length === 0 ? (
+          <p className="text-center text-gray-500">ยังไม่มีประกาศแนะนำในขณะนี้</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+            {featuredProperties.map((property) => (
+              <UserPropertyCard
+                key={property.id}
+                property={property}
+                onViewDetails={handleViewDetails}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
-      {selectedProperty && <PropertyModal propertyId={selectedProperty} onClose={handleCloseModal} />}
+      <UserPropertyModal
+        open={Boolean(selectedProperty)}
+        property={selectedProperty}
+        onOpenChange={handleModalChange}
+      />
     </section>
   )
 }

--- a/components/property-listings.tsx
+++ b/components/property-listings.tsx
@@ -1,47 +1,43 @@
 "use client"
 
-import { useState } from "react"
-import PropertyCard from "./property-card"
-import PropertyModal from "./property-modal"
+import { useMemo, useState } from "react"
 import { Grid, List, ChevronLeft, ChevronRight } from "lucide-react"
-import MobileFilterDrawer from "./mobile-filter-drawer"
 
-const allProperties = [
-  {
-    id: 4,
-    title: "ลอฟต์ใจกลางเมือง",
-    price: "$380,000",
-    location: "321 ถนนบรอดเวย์ ใจกลางเมือง",
-    beds: 1,
-    baths: 1,
-    sqft: 750,
-    type: "sale" as const,
-    gradient: "bg-gradient-to-r from-yellow-400 to-orange-500",
-  },
-  {
-    id: 5,
-    title: "วิลล่าสวน",
-    price: "$3,200/mo",
-    location: "654 ซอยการ์เดน ย่านฝั่งตะวันตก",
-    beds: 4,
-    baths: 3,
-    sqft: 1800,
-    type: "rent" as const,
-    gradient: "bg-gradient-to-r from-teal-400 to-blue-500",
-  },
-]
+import { useAllUserProperties } from "@/hooks/use-all-user-properties"
+import type { UserProperty } from "@/types/user-property"
+
+import MobileFilterDrawer from "./mobile-filter-drawer"
+import { UserPropertyCard } from "./user-property-card"
+import { UserPropertyModal } from "./user-property-modal"
+
+const BEDROOM_OPTIONS = ["1+", "2+", "3+", "4+"]
 
 export default function PropertyListings() {
-  const [selectedProperty, setSelectedProperty] = useState<number | null>(null)
+  const { properties, loading, error } = useAllUserProperties()
+  const [selectedProperty, setSelectedProperty] = useState<UserProperty | null>(null)
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
   const [selectedBedrooms, setSelectedBedrooms] = useState<string | null>(null)
 
-  const handleViewDetails = (id: number) => {
-    setSelectedProperty(id)
+  const filteredProperties = useMemo(() => {
+    if (!selectedBedrooms) return properties
+
+    const minBedrooms = parseInt(selectedBedrooms, 10)
+    if (!Number.isFinite(minBedrooms)) return properties
+
+    return properties.filter((property) => {
+      const numericBedrooms = Number(property.bedrooms)
+      return Number.isFinite(numericBedrooms) && numericBedrooms >= minBedrooms
+    })
+  }, [properties, selectedBedrooms])
+
+  const handleViewDetails = (property: UserProperty) => {
+    setSelectedProperty(property)
   }
 
-  const handleCloseModal = () => {
-    setSelectedProperty(null)
+  const handleModalChange = (open: boolean) => {
+    if (!open) {
+      setSelectedProperty(null)
+    }
   }
 
   const handleApplyFilters = () => {
@@ -53,43 +49,49 @@ export default function PropertyListings() {
   }
 
   return (
-    <section className="py-16 bg-white">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="bg-white py-16">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col lg:flex-row gap-8">
           {/* Filters Sidebar */}
           <div className="lg:w-1/4">
-            <div className="bg-gray-50 rounded-lg p-4 sm:p-6 sticky top-24">
-              <div className="flex items-center justify-between mb-4 sm:mb-6">
-                <h3 className="text-lg sm:text-xl font-semibold text-gray-800">ตัวกรอง</h3>
-                <button className="text-blue-600 hover:text-blue-700 text-sm">ล้างทั้งหมด</button>
+            <div className="sticky top-24 rounded-lg bg-gray-50 p-4 sm:p-6">
+              <div className="mb-4 flex items-center justify-between sm:mb-6">
+                <h3 className="text-lg font-semibold text-gray-800 sm:text-xl">ตัวกรอง</h3>
+                <button
+                  className="text-sm text-blue-600 hover:text-blue-700"
+                  onClick={() => setSelectedBedrooms(null)}
+                >
+                  ล้างทั้งหมด
+                </button>
               </div>
 
               {/* Price Range */}
               <div className="mb-4 sm:mb-6">
-                <label className="block text-sm font-medium text-gray-700 mb-2">ช่วงราคา</label>
+                <label className="mb-2 block text-sm font-medium text-gray-700">ช่วงราคา</label>
                 <div className="grid grid-cols-2 gap-2">
                   <input
                     type="number"
                     placeholder="ต่ำสุด"
-                    className="px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                    className="rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                   <input
                     type="number"
                     placeholder="สูงสุด"
-                    className="px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                    className="rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
               </div>
 
               {/* Property Type */}
               <div className="mb-4 sm:mb-6">
-                <label className="block text-sm font-medium text-gray-700 mb-2">ประเภทอสังหาริมทรัพย์</label>
+                <label className="mb-2 block text-sm font-medium text-gray-700">ประเภทอสังหาริมทรัพย์</label>
                 <div className="space-y-2">
                   {["บ้าน", "อพาร์ตเมนต์", "คอนโด", "ที่ดิน"].map((type) => (
                     <label key={type} className="flex items-center">
                       <input
                         type="checkbox"
                         className="mr-2 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                        disabled
                       />
                       <span className="text-sm sm:text-base">{type}</span>
                     </label>
@@ -99,9 +101,9 @@ export default function PropertyListings() {
 
               {/* Bedrooms */}
               <div className="mb-4 sm:mb-6">
-                <label className="block text-sm font-medium text-gray-700 mb-2">จำนวนห้องนอน</label>
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                  {["1+", "2+", "3+", "4+"].map((bedrooms) => (
+                <label className="mb-2 block text-sm font-medium text-gray-700">จำนวนห้องนอน</label>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  {BEDROOM_OPTIONS.map((bedrooms) => (
                     <button
                       key={bedrooms}
                       onClick={() => handleBedroomFilter(bedrooms)}
@@ -119,7 +121,7 @@ export default function PropertyListings() {
 
               <button
                 onClick={handleApplyFilters}
-                className="w-full bg-blue-600 text-white py-2.5 sm:py-2 rounded-lg hover:bg-blue-700 transition text-sm sm:text-base"
+                className="w-full rounded-lg bg-blue-600 py-2.5 text-sm text-white transition hover:bg-blue-700 sm:py-2 sm:text-base"
               >
                 ใช้ตัวกรอง
               </button>
@@ -128,19 +130,19 @@ export default function PropertyListings() {
 
           {/* Listings */}
           <div className="lg:w-3/4">
-            <div className="flex flex-col space-y-4 sm:space-y-0 sm:flex-row sm:justify-between sm:items-center mb-6">
-              <h2 className="text-xl sm:text-2xl font-bold text-gray-800">อสังหาริมทรัพย์ทั้งหมด</h2>
-              <div className="flex flex-col space-y-2 sm:space-y-0 sm:flex-row sm:items-center sm:space-x-4">
-                <select className="px-3 sm:px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm sm:text-base">
+            <div className="mb-6 flex flex-col space-y-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
+              <h2 className="text-xl font-bold text-gray-800 sm:text-2xl">อสังหาริมทรัพย์ทั้งหมด</h2>
+              <div className="flex flex-col space-y-2 sm:flex-row sm:items-center sm:space-x-4 sm:space-y-0">
+                <select className="rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 sm:px-4 sm:text-base">
                   <option>เรียงโดย: ใหม่ล่าสุด</option>
                   <option>ราคา: จากต่ำไปสูง</option>
                   <option>ราคา: จากสูงไปต่ำ</option>
                   <option>ขนาด: ใหญ่ที่สุดก่อน</option>
                 </select>
-                <div className="flex border rounded-lg self-start sm:self-auto">
+                <div className="flex self-start rounded-lg border sm:self-auto">
                   <button
                     onClick={() => setViewMode("grid")}
-                    className={`px-3 py-2 rounded-l-lg transition-colors ${
+                    className={`rounded-l-lg px-3 py-2 transition-colors ${
                       viewMode === "grid" ? "bg-blue-600 text-white" : "hover:bg-gray-50"
                     }`}
                   >
@@ -148,7 +150,7 @@ export default function PropertyListings() {
                   </button>
                   <button
                     onClick={() => setViewMode("list")}
-                    className={`px-3 py-2 border-l rounded-r-lg transition-colors ${
+                    className={`rounded-r-lg border-l px-3 py-2 transition-colors ${
                       viewMode === "list" ? "bg-blue-600 text-white" : "hover:bg-gray-50"
                     }`}
                   >
@@ -158,13 +160,41 @@ export default function PropertyListings() {
               </div>
             </div>
 
-            <div
-              className={`grid gap-4 sm:gap-6 ${viewMode === "grid" ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1"}`}
-            >
-              {allProperties.map((property) => (
-                <PropertyCard key={property.id} {...property} onViewDetails={handleViewDetails} />
-              ))}
-            </div>
+            {loading ? (
+              <div className="grid gap-4 sm:grid-cols-2 sm:gap-6">
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="flex h-full flex-col overflow-hidden rounded-2xl border bg-white p-4 shadow-sm animate-pulse"
+                  >
+                    <div className="mb-4 h-40 w-full rounded-xl bg-gray-200" />
+                    <div className="space-y-3">
+                      <div className="h-4 w-3/4 rounded bg-gray-200" />
+                      <div className="h-4 w-1/2 rounded bg-gray-200" />
+                      <div className="h-4 w-full rounded bg-gray-200" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : error ? (
+              <p className="text-sm text-red-600">{error}</p>
+            ) : filteredProperties.length === 0 ? (
+              <p className="text-gray-500">ไม่พบอสังหาริมทรัพย์ที่ตรงกับการค้นหาของคุณ</p>
+            ) : (
+              <div
+                className={`grid gap-4 sm:gap-6 ${
+                  viewMode === "grid" ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1"
+                }`}
+              >
+                {filteredProperties.map((property) => (
+                  <UserPropertyCard
+                    key={property.id}
+                    property={property}
+                    onViewDetails={handleViewDetails}
+                  />
+                ))}
+              </div>
+            )}
 
             {/* Pagination */}
             <div className="flex justify-center mt-12">
@@ -184,7 +214,11 @@ export default function PropertyListings() {
         </div>
       </div>
 
-      {selectedProperty && <PropertyModal propertyId={selectedProperty} onClose={handleCloseModal} />}
+      <UserPropertyModal
+        open={Boolean(selectedProperty)}
+        property={selectedProperty}
+        onOpenChange={handleModalChange}
+      />
 
       <MobileFilterDrawer
         selectedBedrooms={selectedBedrooms}

--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ArrowLeft } from "lucide-react";
+
+import ChatWidget from "@/components/chat-widget";
+import { UserPropertyCard } from "@/components/user-property-card";
+import { UserPropertyModal } from "@/components/user-property-modal";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { useUserProfile } from "@/hooks/use-user-profile";
+import { useUserProperties } from "@/hooks/use-user-properties";
+import type { UserProperty } from "@/types/user-property";
+
+interface UserProfilePageProps {
+  uid: string;
+}
+
+export function UserProfilePage({ uid }: UserProfilePageProps) {
+  const {
+    profile,
+    loading: profileLoading,
+    error: profileError,
+  } = useUserProfile(uid);
+  const {
+    properties,
+    loading: propertiesLoading,
+    error: propertiesError,
+  } = useUserProperties(uid);
+  const [selectedProperty, setSelectedProperty] = useState<UserProperty | null>(
+    null,
+  );
+
+  const profileInitials = useMemo(() => {
+    const name = profile?.name || "ผู้ขาย";
+    return name
+      .split(" ")
+      .map((segment) => segment.charAt(0))
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }, [profile?.name]);
+
+  const totalListings = properties.length;
+
+  const handleViewDetails = (property: UserProperty) => {
+    setSelectedProperty(property);
+  };
+
+  const handleModalChange = (open: boolean) => {
+    if (!open) {
+      setSelectedProperty(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/buy"
+              className="inline-flex items-center text-sm text-blue-600 hover:text-blue-700"
+            >
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              กลับไปหน้าซื้อ
+            </Link>
+            <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+              ข้อมูลผู้ขาย
+            </h1>
+          </div>
+        </div>
+
+        <Card>
+          <CardContent className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-1 flex-col gap-4 sm:flex-row sm:items-center">
+              <Avatar className="h-20 w-20 border">
+                <AvatarImage
+                  src={profile?.photoURL ?? ""}
+                  alt={profile?.name ?? "ผู้ขาย"}
+                />
+                <AvatarFallback className="text-lg">
+                  {profileInitials}
+                </AvatarFallback>
+              </Avatar>
+              <div className="space-y-2">
+                {profileLoading ? (
+                  <p className="text-sm text-muted-foreground">
+                    กำลังโหลดข้อมูลผู้ขาย...
+                  </p>
+                ) : profileError ? (
+                  <p className="text-sm text-red-600">{profileError}</p>
+                ) : profile ? (
+                  <>
+                    <p className="text-2xl font-semibold text-gray-900">
+                      {profile.name}
+                    </p>
+                    {profile.email && (
+                      <p className="text-sm text-gray-600">
+                        อีเมล: {profile.email}
+                      </p>
+                    )}
+                    {profile.phoneNumber && (
+                      <p className="text-sm text-gray-600">
+                        เบอร์โทร: {profile.phoneNumber}
+                      </p>
+                    )}
+                    <p className="text-sm text-gray-500">
+                      ประกาศทั้งหมด {totalListings} รายการ
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-sm text-gray-600">ไม่พบข้อมูลผู้ขาย</p>
+                )}
+              </div>
+            </div>
+
+            <div className="flex w-full flex-col gap-2 sm:w-auto">
+              {profile?.email && (
+                <Button asChild variant="outline">
+                  <a href={`mailto:${profile.email}`}>ติดต่อผู้ขายผ่านอีเมล</a>
+                </Button>
+              )}
+              {profile?.phoneNumber && (
+                <Button asChild>
+                  <a href={`tel:${profile.phoneNumber}`}>โทรหาผู้ขาย</a>
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <section className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-xl font-semibold text-gray-900">
+              ประกาศของผู้ขายรายนี้
+            </h2>
+            <p className="text-sm text-gray-500">แสดง {totalListings} รายการ</p>
+          </div>
+
+          {propertiesLoading ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="flex h-full flex-col overflow-hidden rounded-2xl border bg-white p-4 shadow-sm animate-pulse"
+                >
+                  <div className="mb-4 h-40 w-full rounded-xl bg-gray-200" />
+                  <div className="space-y-3">
+                    <div className="h-4 w-3/4 rounded bg-gray-200" />
+                    <div className="h-4 w-1/2 rounded bg-gray-200" />
+                    <div className="h-4 w-full rounded bg-gray-200" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : propertiesError ? (
+            <p className="text-sm text-red-600">{propertiesError}</p>
+          ) : properties.length === 0 ? (
+            <p className="text-gray-500">ผู้ขายรายนี้ยังไม่มีประกาศขาย</p>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {properties.map((property) => (
+                <UserPropertyCard
+                  key={property.id}
+                  property={property}
+                  onViewDetails={handleViewDetails}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <UserPropertyModal
+        open={Boolean(selectedProperty)}
+        property={selectedProperty}
+        onOpenChange={handleModalChange}
+      />
+
+      <ChatWidget />
+    </div>
+  );
+}

--- a/components/user-property-modal.tsx
+++ b/components/user-property-modal.tsx
@@ -1,7 +1,8 @@
-"use client"
+"use client";
 
-import Image from "next/image"
-import { useEffect, useMemo, useState } from "react"
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
 import {
   Bath,
   Bed,
@@ -13,142 +14,189 @@ import {
   Mail,
   Ruler,
   Square,
-  User,
   Video,
-} from "lucide-react"
+} from "lucide-react";
 
-import { Badge } from "@/components/ui/badge"
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
+} from "@/components/ui/dialog";
+import { useUserProfile } from "@/hooks/use-user-profile";
+import { useUserProperties } from "@/hooks/use-user-properties";
 import {
   formatPropertyPrice,
   PROPERTY_TYPE_LABELS,
   SELLER_ROLE_LABELS,
   TRANSACTION_LABELS,
-} from "@/lib/property"
-import { cn } from "@/lib/utils"
-import type { UserProperty } from "@/types/user-property"
+} from "@/lib/property";
+import { cn } from "@/lib/utils";
+import type { UserProperty } from "@/types/user-property";
 
 interface UserPropertyModalProps {
-  open: boolean
-  property: UserProperty | null
-  onOpenChange: (open: boolean) => void
+  open: boolean;
+  property: UserProperty | null;
+  onOpenChange: (open: boolean) => void;
 }
 
-export function UserPropertyModal({ open, property, onOpenChange }: UserPropertyModalProps) {
-  const [activeMediaIndex, setActiveMediaIndex] = useState(0)
+export function UserPropertyModal({
+  open,
+  property,
+  onOpenChange,
+}: UserPropertyModalProps) {
+  const [activeMediaIndex, setActiveMediaIndex] = useState(0);
+
+  const userUid = property?.userUid?.trim() ? property.userUid : null;
+  const {
+    profile: sellerProfile,
+    loading: sellerProfileLoading,
+    error: sellerProfileError,
+  } = useUserProfile(userUid);
+  const {
+    properties: sellerListings,
+    loading: sellerListingsLoading,
+    error: sellerListingsError,
+  } = useUserProperties(userUid);
 
   useEffect(() => {
-    setActiveMediaIndex(0)
-  }, [property?.id])
+    setActiveMediaIndex(0);
+  }, [property?.id]);
 
   const mediaItems = useMemo(() => {
-    if (!property) return []
+    if (!property) return [];
 
     const items = (property.photos ?? [])
-      .filter((photo): photo is string => typeof photo === "string" && photo.trim().length > 0)
+      .filter(
+        (photo): photo is string =>
+          typeof photo === "string" && photo.trim().length > 0,
+      )
       .map((photo, index) => ({
         id: `photo-${index}`,
         type: "image" as const,
         url: photo,
-      }))
+      }));
 
     if (property.video) {
       items.push({
         id: "video",
         type: "video" as const,
         url: property.video,
-      })
+      });
     }
 
-    return items
-  }, [property])
+    return items;
+  }, [property]);
 
-  const safeIndex = mediaItems.length > 0 ? Math.min(activeMediaIndex, mediaItems.length - 1) : 0
-  const activeMedia = mediaItems[safeIndex]
+  const safeIndex =
+    mediaItems.length > 0
+      ? Math.min(activeMediaIndex, mediaItems.length - 1)
+      : 0;
+  const activeMedia = mediaItems[safeIndex];
 
   const locationText = useMemo(() => {
-    if (!property) return ""
+    if (!property) return "";
     const segments = [property.address, property.city, property.province]
       .map((segment) => segment?.trim())
-      .filter(Boolean)
-    return segments.join(", ")
-  }, [property])
+      .filter(Boolean);
+    return segments.join(", ");
+  }, [property]);
 
   const createdAtDisplay = useMemo(() => {
-    if (!property?.createdAt) return null
-    const date = new Date(property.createdAt)
-    if (Number.isNaN(date.getTime())) return null
+    if (!property?.createdAt) return null;
+    const date = new Date(property.createdAt);
+    if (Number.isNaN(date.getTime())) return null;
     return date.toLocaleDateString("th-TH", {
       dateStyle: "medium",
       timeZone: "Asia/Bangkok",
-    })
-  }, [property])
+    });
+  }, [property]);
 
   const landAreaDisplay = useMemo(() => {
-    if (!property) return ""
-    const numeric = Number(property.landArea)
+    if (!property) return "";
+    const numeric = Number(property.landArea);
     if (Number.isFinite(numeric) && numeric > 0) {
-      return `${numeric.toLocaleString("th-TH")} ตร.ว.`
+      return `${numeric.toLocaleString("th-TH")} ตร.ว.`;
     }
-    return property.landArea
-  }, [property])
+    return property.landArea;
+  }, [property]);
 
   const usableAreaDisplay = useMemo(() => {
-    if (!property) return ""
-    const numeric = Number(property.usableArea)
+    if (!property) return "";
+    const numeric = Number(property.usableArea);
     if (Number.isFinite(numeric) && numeric > 0) {
-      return `${numeric.toLocaleString("th-TH")} ตร.ม.`
+      return `${numeric.toLocaleString("th-TH")} ตร.ม.`;
     }
-    return property.usableArea
-  }, [property])
+    return property.usableArea;
+  }, [property]);
 
   const bedroomsDisplay = useMemo(() => {
-    if (!property) return "-"
-    const numeric = Number(property.bedrooms)
-    if (Number.isFinite(numeric) && numeric > 0) return numeric
-    return property.bedrooms || "-"
-  }, [property])
+    if (!property) return "-";
+    const numeric = Number(property.bedrooms);
+    if (Number.isFinite(numeric) && numeric > 0) return numeric;
+    return property.bedrooms || "-";
+  }, [property]);
 
   const bathroomsDisplay = useMemo(() => {
-    if (!property) return "-"
-    const numeric = Number(property.bathrooms)
-    if (Number.isFinite(numeric) && numeric > 0) return numeric
-    return property.bathrooms || "-"
-  }, [property])
+    if (!property) return "-";
+    const numeric = Number(property.bathrooms);
+    if (Number.isFinite(numeric) && numeric > 0) return numeric;
+    return property.bathrooms || "-";
+  }, [property]);
 
   const parkingDisplay = useMemo(() => {
-    if (!property?.parking) return null
-    if (property.parking === "none") return "ไม่มีที่จอดรถ"
-    const numeric = Number(property.parking)
+    if (!property?.parking) return null;
+    if (property.parking === "none") return "ไม่มีที่จอดรถ";
+    const numeric = Number(property.parking);
     if (Number.isFinite(numeric) && numeric >= 0) {
-      return `${numeric} คัน`
+      return `${numeric} คัน`;
     }
-    return property.parking
-  }, [property])
+    return property.parking;
+  }, [property]);
 
-  if (!property) return null
+  if (!property) return null;
 
-  const sellerRoleLabel = SELLER_ROLE_LABELS[property.sellerRole] ?? property.sellerRole
-  const transactionLabel = TRANSACTION_LABELS[property.transactionType] ?? property.transactionType
-  const typeLabel = PROPERTY_TYPE_LABELS[property.propertyType] ?? property.propertyType
+  const sellerRoleLabel =
+    SELLER_ROLE_LABELS[property.sellerRole] ?? property.sellerRole;
+  const transactionLabel =
+    TRANSACTION_LABELS[property.transactionType] ?? property.transactionType;
+  const typeLabel =
+    PROPERTY_TYPE_LABELS[property.propertyType] ?? property.propertyType;
+  const sellerDisplayName = sellerProfile?.name || property.sellerName;
+  const sellerPhone = property.sellerPhone || sellerProfile?.phoneNumber || "";
+  const sellerEmail = property.sellerEmail || sellerProfile?.email || "";
+  const sellerInitials = useMemo(() => {
+    const name = sellerProfile?.name || property.sellerName || "";
+    if (!name) return "?";
+    return name
+      .split(" ")
+      .map((segment) => segment.charAt(0))
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }, [property.sellerName, sellerProfile?.name]);
+  const sellerListingsCount = useMemo(
+    () => sellerListings.length,
+    [sellerListings],
+  );
 
   const mapUrl =
     typeof property.lat === "number" && typeof property.lng === "number"
       ? `https://www.google.com/maps?q=${property.lat},${property.lng}&hl=th&z=16&output=embed`
-      : null
+      : null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="w-full max-w-[calc(100vw-2rem)] max-h-[calc(100vh-3rem)] overflow-y-auto overflow-x-hidden p-3 xs:p-4 sm:max-w-3xl sm:max-h-[90vh] sm:p-6 md:max-w-5xl lg:max-w-6xl lg:p-8 xl:max-w-7xl">
         <DialogHeader className="space-y-4">
           <div className="space-y-2">
-            <DialogTitle className="text-xl font-bold text-gray-900 sm:text-2xl">{property.title}</DialogTitle>
+            <DialogTitle className="text-xl font-bold text-gray-900 sm:text-2xl">
+              {property.title}
+            </DialogTitle>
             <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground sm:gap-3">
               <span className="flex items-center gap-1">
                 <MapPin className="h-4 w-4" />
@@ -163,7 +211,9 @@ export function UserPropertyModal({ open, property, onOpenChange }: UserProperty
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-            <Badge className="bg-blue-600 text-white hover:bg-blue-600">{transactionLabel}</Badge>
+            <Badge className="bg-blue-600 text-white hover:bg-blue-600">
+              {transactionLabel}
+            </Badge>
             <Badge variant="outline">{typeLabel}</Badge>
             <DialogDescription className="text-2xl font-bold text-blue-600 sm:text-3xl">
               {formatPropertyPrice(property.price, property.transactionType)}
@@ -230,41 +280,55 @@ export function UserPropertyModal({ open, property, onOpenChange }: UserProperty
             </section>
 
             <section className="space-y-3 rounded-2xl border bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-gray-900">รายละเอียด</h3>
+              <h3 className="text-lg font-semibold text-gray-900">
+                รายละเอียด
+              </h3>
               <p className="whitespace-pre-line break-words text-sm leading-relaxed text-gray-700">
                 {property.description || "ไม่มีรายละเอียดเพิ่มเติม"}
               </p>
             </section>
 
             <section className="space-y-4 rounded-2xl border bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-gray-900">ข้อมูลทรัพย์สิน</h3>
+              <h3 className="text-lg font-semibold text-gray-900">
+                ข้อมูลทรัพย์สิน
+              </h3>
               <div className="grid gap-4 xs:grid-cols-2">
                 <div className="flex items-center gap-3 rounded-xl border p-4">
                   <Bed className="h-5 w-5 text-blue-600" />
                   <div>
                     <p className="text-sm text-muted-foreground">ห้องนอน</p>
-                    <p className="text-base font-semibold text-gray-900">{bedroomsDisplay}</p>
+                    <p className="text-base font-semibold text-gray-900">
+                      {bedroomsDisplay}
+                    </p>
                   </div>
                 </div>
                 <div className="flex items-center gap-3 rounded-xl border p-4">
                   <Bath className="h-5 w-5 text-blue-600" />
                   <div>
                     <p className="text-sm text-muted-foreground">ห้องน้ำ</p>
-                    <p className="text-base font-semibold text-gray-900">{bathroomsDisplay}</p>
+                    <p className="text-base font-semibold text-gray-900">
+                      {bathroomsDisplay}
+                    </p>
                   </div>
                 </div>
                 <div className="flex items-center gap-3 rounded-xl border p-4">
                   <Ruler className="h-5 w-5 text-blue-600" />
                   <div>
                     <p className="text-sm text-muted-foreground">พื้นที่ดิน</p>
-                    <p className="text-base font-semibold text-gray-900">{landAreaDisplay || "-"}</p>
+                    <p className="text-base font-semibold text-gray-900">
+                      {landAreaDisplay || "-"}
+                    </p>
                   </div>
                 </div>
                 <div className="flex items-center gap-3 rounded-xl border p-4">
                   <Square className="h-5 w-5 text-blue-600" />
                   <div>
-                    <p className="text-sm text-muted-foreground">พื้นที่ใช้สอย</p>
-                    <p className="text-base font-semibold text-gray-900">{usableAreaDisplay || "-"}</p>
+                    <p className="text-sm text-muted-foreground">
+                      พื้นที่ใช้สอย
+                    </p>
+                    <p className="text-base font-semibold text-gray-900">
+                      {usableAreaDisplay || "-"}
+                    </p>
                   </div>
                 </div>
                 {parkingDisplay && (
@@ -272,7 +336,9 @@ export function UserPropertyModal({ open, property, onOpenChange }: UserProperty
                     <Car className="h-5 w-5 text-blue-600" />
                     <div>
                       <p className="text-sm text-muted-foreground">ที่จอดรถ</p>
-                      <p className="text-base font-semibold text-gray-900">{parkingDisplay}</p>
+                      <p className="text-base font-semibold text-gray-900">
+                        {parkingDisplay}
+                      </p>
                     </div>
                   </div>
                 )}
@@ -280,8 +346,12 @@ export function UserPropertyModal({ open, property, onOpenChange }: UserProperty
                   <div className="flex items-center gap-3 rounded-xl border p-4">
                     <Calendar className="h-5 w-5 text-blue-600" />
                     <div>
-                      <p className="text-sm text-muted-foreground">สร้างเมื่อปี</p>
-                      <p className="text-base font-semibold text-gray-900">{property.yearBuilt}</p>
+                      <p className="text-sm text-muted-foreground">
+                        สร้างเมื่อปี
+                      </p>
+                      <p className="text-base font-semibold text-gray-900">
+                        {property.yearBuilt}
+                      </p>
                     </div>
                   </div>
                 )}
@@ -310,29 +380,76 @@ export function UserPropertyModal({ open, property, onOpenChange }: UserProperty
             </section>
 
             <section className="space-y-4 rounded-2xl border bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-gray-900">ข้อมูลผู้ขาย</h3>
-              <div className="space-y-3 text-sm text-gray-700">
-                <div className="flex items-center gap-3">
-                  <User className="h-5 w-5 text-blue-600" />
-                  <div>
-                    <p className="text-base font-semibold text-gray-900">{property.sellerName}</p>
-                    <p className="text-muted-foreground">{sellerRoleLabel}</p>
+              <h3 className="text-lg font-semibold text-gray-900">
+                ข้อมูลผู้ขาย
+              </h3>
+              <div className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <Avatar className="h-12 w-12 border">
+                    <AvatarImage
+                      src={sellerProfile?.photoURL ?? ""}
+                      alt={sellerDisplayName}
+                    />
+                    <AvatarFallback>{sellerInitials}</AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 space-y-1">
+                    <p className="text-base font-semibold text-gray-900">
+                      {sellerDisplayName}
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      {sellerRoleLabel}
+                    </p>
+                    {sellerProfile?.phoneVerified && (
+                      <Badge className="mt-1 w-fit border-emerald-200 bg-emerald-50 text-xs font-medium text-emerald-600">
+                        ยืนยันเบอร์โทรแล้ว
+                      </Badge>
+                    )}
                   </div>
                 </div>
-                <a
-                  href={`tel:${property.sellerPhone}`}
-                  className="flex flex-wrap items-center gap-2 text-blue-600 hover:underline sm:flex-nowrap sm:gap-3"
-                >
-                  <Phone className="h-5 w-5" />
-                  {property.sellerPhone}
-                </a>
-                <a
-                  href={`mailto:${property.sellerEmail}`}
-                  className="flex flex-wrap items-center gap-2 text-blue-600 hover:underline break-all sm:flex-nowrap sm:gap-3"
-                >
-                  <Mail className="h-5 w-5" />
-                  {property.sellerEmail}
-                </a>
+
+                {sellerProfileLoading && (
+                  <p className="text-sm text-muted-foreground">
+                    กำลังโหลดข้อมูลผู้ขาย...
+                  </p>
+                )}
+                {sellerProfileError && (
+                  <p className="text-sm text-red-600">{sellerProfileError}</p>
+                )}
+
+                <div className="space-y-3 text-sm text-gray-700">
+                  {sellerPhone && (
+                    <a
+                      href={`tel:${sellerPhone}`}
+                      className="flex flex-wrap items-center gap-2 text-blue-600 hover:underline sm:flex-nowrap sm:gap-3"
+                    >
+                      <Phone className="h-5 w-5" />
+                      {sellerPhone}
+                    </a>
+                  )}
+                  {sellerEmail && (
+                    <a
+                      href={`mailto:${sellerEmail}`}
+                      className="flex flex-wrap items-center gap-2 break-all text-blue-600 hover:underline sm:flex-nowrap sm:gap-3"
+                    >
+                      <Mail className="h-5 w-5" />
+                      {sellerEmail}
+                    </a>
+                  )}
+                </div>
+
+                {sellerListingsError && (
+                  <p className="text-sm text-red-600">{sellerListingsError}</p>
+                )}
+
+                {property.userUid && (
+                  <Link href={`/users/${property.userUid}`} className="block">
+                    <Button variant="outline" className="w-full justify-center">
+                      {sellerListingsLoading
+                        ? "กำลังโหลดประกาศจากผู้ขาย..."
+                        : `ดูประกาศทั้งหมดจากผู้ขายรายนี้ (${sellerListingsCount})`}
+                    </Button>
+                  </Link>
+                )}
               </div>
             </section>
 
@@ -340,12 +457,16 @@ export function UserPropertyModal({ open, property, onOpenChange }: UserProperty
               <h3 className="text-lg font-semibold text-gray-900">ที่อยู่</h3>
               <div className="space-y-1 text-sm text-gray-700">
                 <p>{property.address}</p>
-                <p>{[property.city, property.province, property.postal].filter(Boolean).join(" ")}</p>
+                <p>
+                  {[property.city, property.province, property.postal]
+                    .filter(Boolean)
+                    .join(" ")}
+                </p>
               </div>
             </section>
           </aside>
         </div>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/components/user-property-modal.tsx
+++ b/components/user-property-modal.tsx
@@ -158,6 +158,18 @@ export function UserPropertyModal({
     return property.parking;
   }, [property]);
 
+  const sellerInitials = useMemo(() => {
+    const name = sellerProfile?.name || property?.sellerName || "";
+    if (!name) return "?";
+    return name
+      .split(" ")
+      .map((segment) => segment.charAt(0))
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }, [property?.sellerName, sellerProfile?.name]);
+  const sellerListingsCount = sellerListings.length;
+
   if (!property) return null;
 
   const sellerRoleLabel =
@@ -169,20 +181,6 @@ export function UserPropertyModal({
   const sellerDisplayName = sellerProfile?.name || property.sellerName;
   const sellerPhone = property.sellerPhone || sellerProfile?.phoneNumber || "";
   const sellerEmail = property.sellerEmail || sellerProfile?.email || "";
-  const sellerInitials = useMemo(() => {
-    const name = sellerProfile?.name || property.sellerName || "";
-    if (!name) return "?";
-    return name
-      .split(" ")
-      .map((segment) => segment.charAt(0))
-      .join("")
-      .slice(0, 2)
-      .toUpperCase();
-  }, [property.sellerName, sellerProfile?.name]);
-  const sellerListingsCount = useMemo(
-    () => sellerListings.length,
-    [sellerListings],
-  );
 
   const mapUrl =
     typeof property.lat === "number" && typeof property.lng === "number"

--- a/hooks/use-all-user-properties.ts
+++ b/hooks/use-all-user-properties.ts
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import { subscribeToCollection } from "@/lib/firestore"
+import {
+  mapDocumentToUserProperty,
+  parseUserPropertyCreatedAt,
+} from "@/lib/user-property-mapper"
+import type { UserProperty } from "@/types/user-property"
+
+interface UseAllUserPropertiesResult {
+  properties: UserProperty[]
+  loading: boolean
+  error: string | null
+}
+
+export function useAllUserProperties(): UseAllUserPropertiesResult {
+  const [properties, setProperties] = useState<UserProperty[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined
+    let isActive = true
+
+    const loadProperties = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        unsubscribe = await subscribeToCollection("property", (docs) => {
+          if (!isActive) return
+
+          const mapped = docs.map(mapDocumentToUserProperty)
+          mapped.sort(
+            (a, b) =>
+              parseUserPropertyCreatedAt(b.createdAt) -
+              parseUserPropertyCreatedAt(a.createdAt),
+          )
+
+          setProperties(mapped)
+          setLoading(false)
+        })
+      } catch (error) {
+        console.error("Failed to load properties:", error)
+        if (!isActive) return
+        setProperties([])
+        setError("ไม่สามารถโหลดรายการอสังหาริมทรัพย์ได้ กรุณาลองใหม่อีกครั้ง")
+        setLoading(false)
+      }
+    }
+
+    void loadProperties()
+
+    return () => {
+      isActive = false
+      if (unsubscribe) {
+        unsubscribe()
+      }
+    }
+  }, [])
+
+  return { properties, loading, error }
+}

--- a/hooks/use-user-profile.ts
+++ b/hooks/use-user-profile.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { subscribeToDocument } from "@/lib/firestore";
+import { mapDocumentToUserProfile } from "@/lib/user-profile-mapper";
+import type { UserProfile } from "@/types/user-profile";
+
+interface UseUserProfileResult {
+  profile: UserProfile | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useUserProfile(userUid: string | null): UseUserProfileResult {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(Boolean(userUid));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+    let isActive = true;
+
+    if (!userUid) {
+      setProfile(null);
+      setLoading(false);
+      setError(null);
+      return () => {};
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const loadProfile = async () => {
+      try {
+        unsubscribe = await subscribeToDocument("users", userUid, (doc) => {
+          if (!isActive) return;
+
+          if (doc) {
+            setProfile(mapDocumentToUserProfile(doc));
+          } else {
+            setProfile(null);
+          }
+          setLoading(false);
+        });
+      } catch (err) {
+        console.error("Failed to load user profile:", err);
+        if (!isActive) return;
+        setProfile(null);
+        setError("ไม่สามารถโหลดข้อมูลผู้ขายได้");
+        setLoading(false);
+      }
+    };
+
+    void loadProfile();
+
+    return () => {
+      isActive = false;
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [userUid]);
+
+  return { profile, loading, error };
+}

--- a/hooks/use-user-properties.ts
+++ b/hooks/use-user-properties.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { subscribeToCollection } from "@/lib/firestore";
+import {
+  mapDocumentToUserProperty,
+  parseUserPropertyCreatedAt,
+} from "@/lib/user-property-mapper";
+import type { UserProperty } from "@/types/user-property";
+
+interface UseUserPropertiesResult {
+  properties: UserProperty[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useUserProperties(
+  userUid: string | null,
+): UseUserPropertiesResult {
+  const [properties, setProperties] = useState<UserProperty[]>([]);
+  const [loading, setLoading] = useState(Boolean(userUid));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+    let isActive = true;
+
+    if (!userUid) {
+      setProperties([]);
+      setLoading(false);
+      setError(null);
+      return () => {};
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const loadProperties = async () => {
+      try {
+        const { where } = await import("firebase/firestore");
+        unsubscribe = await subscribeToCollection(
+          "property",
+          (docs) => {
+            if (!isActive) return;
+
+            const mapped = docs.map(mapDocumentToUserProperty);
+            mapped.sort(
+              (a, b) =>
+                parseUserPropertyCreatedAt(b.createdAt) -
+                parseUserPropertyCreatedAt(a.createdAt),
+            );
+
+            setProperties(mapped);
+            setLoading(false);
+          },
+          where("userUid", "==", userUid),
+        );
+      } catch (err) {
+        console.error("Failed to load user listings:", err);
+        if (!isActive) return;
+        setProperties([]);
+        setError("ไม่สามารถโหลดประกาศของผู้ขายได้");
+        setLoading(false);
+      }
+    };
+
+    void loadProperties();
+
+    return () => {
+      isActive = false;
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [userUid]);
+
+  return { properties, loading, error };
+}

--- a/lib/user-profile-mapper.ts
+++ b/lib/user-profile-mapper.ts
@@ -1,0 +1,50 @@
+import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore";
+
+import type { UserProfile } from "@/types/user-profile";
+
+const toStringOrNull = (value: unknown): string | null => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value))
+    return value.toString();
+  return null;
+};
+
+const toBoolean = (value: unknown): boolean => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") return value.toLowerCase() === "true";
+  return false;
+};
+
+const toIsoStringOrNull = (value: unknown): string | null => {
+  if (typeof value === "string") return value;
+  if (
+    value &&
+    typeof value === "object" &&
+    "toDate" in value &&
+    typeof (value as { toDate?: () => Date }).toDate === "function"
+  ) {
+    const date = (value as { toDate: () => Date }).toDate();
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return null;
+};
+
+export const mapDocumentToUserProfile = (
+  doc: QueryDocumentSnapshot<DocumentData>,
+): UserProfile => {
+  const data = doc.data();
+
+  return {
+    uid: doc.id,
+    name: (toStringOrNull(data.name) ?? "").trim() || "ผู้ใช้งาน",
+    email: toStringOrNull(data.email),
+    photoURL: toStringOrNull(data.photoURL),
+    phoneNumber: toStringOrNull(data.phoneNumber),
+    phoneVerified: toBoolean(data.phoneVerified),
+    createdAt: toIsoStringOrNull(data.createdAt),
+    updatedAt: toIsoStringOrNull(data.updatedAt),
+  };
+};

--- a/lib/user-property-mapper.ts
+++ b/lib/user-property-mapper.ts
@@ -1,0 +1,95 @@
+import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore"
+
+import type { UserProperty } from "@/types/user-property"
+
+const toStringValue = (value: unknown): string => {
+  if (typeof value === "string") return value
+  if (typeof value === "number" && Number.isFinite(value)) return value.toString()
+  return ""
+}
+
+const toOptionalString = (value: unknown): string | null => {
+  if (typeof value === "string") return value || null
+  if (typeof value === "number" && Number.isFinite(value)) return value.toString()
+  return null
+}
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+const toNumberOrZero = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 0
+}
+
+const toIsoString = (value: unknown): string => {
+  if (typeof value === "string") return value
+  if (
+    value &&
+    typeof value === "object" &&
+    "toDate" in value &&
+    typeof (value as { toDate?: () => Date }).toDate === "function"
+  ) {
+    const date = (value as { toDate: () => Date }).toDate()
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+      return date.toISOString()
+    }
+  }
+  return ""
+}
+
+export const parseUserPropertyCreatedAt = (createdAt: string): number => {
+  if (!createdAt) return 0
+  const time = Date.parse(createdAt)
+  return Number.isNaN(time) ? 0 : time
+}
+
+export const mapDocumentToUserProperty = (
+  doc: QueryDocumentSnapshot<DocumentData>,
+): UserProperty => {
+  const data = doc.data()
+  const photos = Array.isArray(data.photos)
+    ? data.photos.filter((item: unknown): item is string => typeof item === "string")
+    : []
+
+  return {
+    id: doc.id,
+    sellerName: toStringValue(data.sellerName),
+    sellerPhone: toStringValue(data.sellerPhone),
+    sellerEmail: toStringValue(data.sellerEmail),
+    sellerRole: toStringValue(data.sellerRole),
+    title: toStringValue(data.title),
+    propertyType: toStringValue(data.propertyType),
+    transactionType: toStringValue(data.transactionType),
+    price: toNumberOrZero(data.price),
+    address: toStringValue(data.address),
+    city: toStringValue(data.city),
+    province: toStringValue(data.province),
+    postal: toStringValue(data.postal),
+    lat: toNumberOrNull(data.lat),
+    lng: toNumberOrNull(data.lng),
+    landArea: toStringValue(data.landArea),
+    usableArea: toStringValue(data.usableArea),
+    bedrooms: toStringValue(data.bedrooms),
+    bathrooms: toStringValue(data.bathrooms),
+    parking: toOptionalString(data.parking),
+    yearBuilt: toOptionalString(data.yearBuilt),
+    description: toStringValue(data.description),
+    photos,
+    video:
+      typeof data.video === "string" && data.video.trim().length > 0
+        ? data.video
+        : null,
+    createdAt: toIsoString(data.createdAt),
+  }
+}

--- a/lib/user-property-mapper.ts
+++ b/lib/user-property-mapper.ts
@@ -1,69 +1,76 @@
-import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore"
+import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore";
 
-import type { UserProperty } from "@/types/user-property"
+import type { UserProperty } from "@/types/user-property";
 
 const toStringValue = (value: unknown): string => {
-  if (typeof value === "string") return value
-  if (typeof value === "number" && Number.isFinite(value)) return value.toString()
-  return ""
-}
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value))
+    return value.toString();
+  return "";
+};
 
 const toOptionalString = (value: unknown): string | null => {
-  if (typeof value === "string") return value || null
-  if (typeof value === "number" && Number.isFinite(value)) return value.toString()
-  return null
-}
+  if (typeof value === "string") return value || null;
+  if (typeof value === "number" && Number.isFinite(value))
+    return value.toString();
+  return null;
+};
 
 const toNumberOrNull = (value: unknown): number | null => {
-  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string") {
-    const parsed = Number(value)
-    return Number.isFinite(parsed) ? parsed : null
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
   }
-  return null
-}
+  return null;
+};
 
 const toNumberOrZero = (value: unknown): number => {
-  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string") {
-    const parsed = Number(value)
-    if (Number.isFinite(parsed)) return parsed
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
   }
-  return 0
-}
+  return 0;
+};
 
 const toIsoString = (value: unknown): string => {
-  if (typeof value === "string") return value
+  if (typeof value === "string") return value;
   if (
     value &&
     typeof value === "object" &&
     "toDate" in value &&
     typeof (value as { toDate?: () => Date }).toDate === "function"
   ) {
-    const date = (value as { toDate: () => Date }).toDate()
+    const date = (value as { toDate: () => Date }).toDate();
     if (date instanceof Date && !Number.isNaN(date.getTime())) {
-      return date.toISOString()
+      return date.toISOString();
     }
   }
-  return ""
-}
+  return "";
+};
 
 export const parseUserPropertyCreatedAt = (createdAt: string): number => {
-  if (!createdAt) return 0
-  const time = Date.parse(createdAt)
-  return Number.isNaN(time) ? 0 : time
-}
+  if (!createdAt) return 0;
+  const time = Date.parse(createdAt);
+  return Number.isNaN(time) ? 0 : time;
+};
 
 export const mapDocumentToUserProperty = (
   doc: QueryDocumentSnapshot<DocumentData>,
 ): UserProperty => {
-  const data = doc.data()
+  const data = doc.data();
   const photos = Array.isArray(data.photos)
-    ? data.photos.filter((item: unknown): item is string => typeof item === "string")
-    : []
+    ? data.photos.filter(
+        (item: unknown): item is string => typeof item === "string",
+      )
+    : [];
 
   return {
     id: doc.id,
+    userUid:
+      toStringValue(data.userUid) ||
+      (doc.ref.parent.parent ? toStringValue(doc.ref.parent.parent.id) : ""),
     sellerName: toStringValue(data.sellerName),
     sellerPhone: toStringValue(data.sellerPhone),
     sellerEmail: toStringValue(data.sellerEmail),
@@ -91,5 +98,5 @@ export const mapDocumentToUserProperty = (
         ? data.video
         : null,
     createdAt: toIsoString(data.createdAt),
-  }
-}
+  };
+};

--- a/types/user-profile.ts
+++ b/types/user-profile.ts
@@ -1,0 +1,10 @@
+export interface UserProfile {
+  uid: string;
+  name: string;
+  email: string | null;
+  photoURL: string | null;
+  phoneNumber: string | null;
+  phoneVerified: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+}

--- a/types/user-property.ts
+++ b/types/user-property.ts
@@ -1,27 +1,28 @@
 export interface UserProperty {
-  id: string
-  sellerName: string
-  sellerPhone: string
-  sellerEmail: string
-  sellerRole: string
-  title: string
-  propertyType: string
-  transactionType: string
-  price: number
-  address: string
-  city: string
-  province: string
-  postal: string
-  lat: number | null
-  lng: number | null
-  landArea: string
-  usableArea: string
-  bedrooms: string
-  bathrooms: string
-  parking?: string | null
-  yearBuilt?: string | null
-  description: string
-  photos: string[]
-  video: string | null
-  createdAt: string
+  id: string;
+  userUid: string;
+  sellerName: string;
+  sellerPhone: string;
+  sellerEmail: string;
+  sellerRole: string;
+  title: string;
+  propertyType: string;
+  transactionType: string;
+  price: number;
+  address: string;
+  city: string;
+  province: string;
+  postal: string;
+  lat: number | null;
+  lng: number | null;
+  landArea: string;
+  usableArea: string;
+  bedrooms: string;
+  bathrooms: string;
+  parking?: string | null;
+  yearBuilt?: string | null;
+  description: string;
+  photos: string[];
+  video: string | null;
+  createdAt: string;
 }


### PR DESCRIPTION
## Summary
- add a shared mapper for Firestore user property documents
- subscribe to the global property collection for buy page sections and render UserProperty cards and modal
- update sell dashboard to use the shared mapper utilities

## Testing
- `npm run lint` *(fails: interactive eslint init prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe884caf083218d3a728ab06a777a