### PR TITLE
Add ability to delete sell listings with storage cleanup

### DIFF
--- a/components/sell-property-form.tsx
+++ b/components/sell-property-form.tsx
@@ -30,7 +30,13 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import { useAuthContext } from "@/contexts/AuthContext"
 import { addDocument, getDocument, setDocument } from "@/lib/firestore"
-import { uploadFile, uploadFiles, getDownloadURL, deleteFile } from "@/lib/storage"
+import {
+  uploadFile,
+  uploadFiles,
+  getDownloadURL,
+  deleteFile,
+  extractStoragePathFromUrl,
+} from "@/lib/storage"
 import { mapDocumentToUserProperty } from "@/lib/user-property-mapper"
 import type { UserProperty } from "@/types/user-property"
 
@@ -52,18 +58,6 @@ const isPositive = (s: string) => {
 }
 const emailOk = (s: string) => /\S+@\S+\.\S+/.test(s)
 const phoneOk = (s: string) => s.replace(/\D/g, "").length >= 6
-
-const extractStoragePath = (url: string): string | null => {
-  try {
-    const parsed = new URL(url)
-    const [, pathPart] = parsed.pathname.split("/o/")
-    if (!pathPart) return null
-    return decodeURIComponent(pathPart)
-  } catch (error) {
-    console.error("Failed to extract storage path", error)
-    return null
-  }
-}
 
 export function SellPropertyForm({ mode, propertyId }: SellPropertyFormProps) {
   const { user, loading } = useAuthContext()
@@ -139,7 +133,7 @@ export function SellPropertyForm({ mode, propertyId }: SellPropertyFormProps) {
     setVideo(file)
     if (file) {
       if (existingVideoUrl) {
-        const path = extractStoragePath(existingVideoUrl)
+        const path = extractStoragePathFromUrl(existingVideoUrl)
         if (path) {
           setRemovedVideoPath(path)
         }
@@ -643,7 +637,7 @@ export function SellPropertyForm({ mode, propertyId }: SellPropertyFormProps) {
 
   const handleRemoveExistingPhoto = (url: string) => {
     setExistingPhotoUrls((prev) => prev.filter((item) => item !== url))
-    const path = extractStoragePath(url)
+    const path = extractStoragePathFromUrl(url)
     if (path) {
       setRemovedPhotoPaths((prev) =>
         prev.includes(path) ? prev : [...prev, path],
@@ -653,7 +647,7 @@ export function SellPropertyForm({ mode, propertyId }: SellPropertyFormProps) {
 
   const handleRemoveExistingVideo = () => {
     if (existingVideoUrl) {
-      const path = extractStoragePath(existingVideoUrl)
+      const path = extractStoragePathFromUrl(existingVideoUrl)
       if (path) {
         setRemovedVideoPath(path)
       }

--- a/components/user-property-card.tsx
+++ b/components/user-property-card.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image"
 import Link from "next/link"
 import { useMemo, useState } from "react"
-import { Bath, Bed, Heart, MapPin, Square } from "lucide-react"
+import { Bath, Bed, Heart, MapPin, Square, Trash2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { formatPropertyPrice, PROPERTY_TYPE_LABELS, TRANSACTION_LABELS } from "@/lib/property"
@@ -14,6 +14,8 @@ interface UserPropertyCardProps {
   property: UserProperty
   onViewDetails: (property: UserProperty) => void
   showEditActions?: boolean
+  onDelete?: (property: UserProperty) => void
+  isDeleting?: boolean
 }
 
 const placeholderGradients: Record<string, string> = {
@@ -26,6 +28,8 @@ export function UserPropertyCard({
   property,
   onViewDetails,
   showEditActions = false,
+  onDelete,
+  isDeleting = false,
 }: UserPropertyCardProps) {
   const [isFavorited, setIsFavorited] = useState(false)
 
@@ -140,13 +144,44 @@ export function UserPropertyCard({
         </div>
 
         <div className="mt-auto pt-2 space-y-2">
-          <Button className="w-full" onClick={() => onViewDetails(property)}>
+          <Button
+            className="w-full"
+            onClick={() => onViewDetails(property)}
+            disabled={isDeleting}
+          >
             ดูรายละเอียด
           </Button>
           {showEditActions && (
-            <Button asChild variant="outline" className="w-full">
-              <Link href={`/sell/edit/${property.id}`}>แก้ไขประกาศ</Link>
-            </Button>
+            <>
+              <Button
+                asChild
+                variant="outline"
+                className={cn(
+                  "w-full",
+                  isDeleting && "pointer-events-none opacity-50",
+                )}
+              >
+                <Link href={`/sell/edit/${property.id}`}>แก้ไขประกาศ</Link>
+              </Button>
+              {onDelete && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  className="w-full"
+                  onClick={() => onDelete(property)}
+                  disabled={isDeleting}
+                >
+                  {isDeleting ? (
+                    "กำลังลบ..."
+                  ) : (
+                    <span className="flex items-center justify-center gap-2">
+                      <Trash2 className="h-4 w-4" />
+                      ลบประกาศ
+                    </span>
+                  )}
+                </Button>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -17,6 +17,18 @@ const getStorageInstance = async (): Promise<FirebaseStorage> => {
   return storageInstance
 }
 
+export const extractStoragePathFromUrl = (url: string): string | null => {
+  try {
+    const parsed = new URL(url)
+    const [, pathPart] = parsed.pathname.split("/o/")
+    if (!pathPart) return null
+    return decodeURIComponent(pathPart)
+  } catch (error) {
+    console.error("Failed to extract storage path", error)
+    return null
+  }
+}
+
 // Upload a file
 export const uploadFile = async (path: string, file: File, metadata?: any): Promise<UploadResult> => {
   try {


### PR DESCRIPTION
## Summary
- add deletion workflow on the sell dashboard that cleans up Firestore documents and storage assets
- expose a reusable helper to extract Firebase Storage paths from download URLs and reuse it in the sell form
- extend the user property card with a delete action and better disabled handling

## Testing
- npm run lint *(fails: requires interactive eslint configuration setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f798e8f48321afb6ab21e394b8de