### PR TITLE
Adjust dialog overlay to keep background visible

### DIFF
--- a/app/chat/[conversationId]/page.tsx
+++ b/app/chat/[conversationId]/page.tsx
@@ -1,0 +1,186 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { ArrowLeft, Home, Image, Info, Phone, Send, Video } from "lucide-react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { ConversationList } from "@/components/chat/conversation-list"
+import {
+  createPlaceholderConversation,
+  findConversationById,
+  type ChatMessage,
+} from "@/lib/mock-chats"
+import { cn } from "@/lib/utils"
+
+type PageProps = {
+  params: Promise<{ conversationId: string }>
+  searchParams?: Promise<{ name?: string; avatar?: string }>
+}
+
+function decodeParam(value?: string) {
+  if (!value) return undefined
+  try {
+    return decodeURIComponent(value)
+  } catch (error) {
+    console.error("Failed to decode query param", error)
+    return value
+  }
+}
+
+export default async function ConversationPage({ params, searchParams }: PageProps) {
+  const { conversationId } = await params
+  const resolvedSearchParams = (await searchParams) ?? {}
+
+  const fallbackName = decodeParam(resolvedSearchParams.name)
+  const fallbackAvatar = decodeParam(resolvedSearchParams.avatar)
+
+  const conversation =
+    findConversationById(conversationId) ||
+    (fallbackName
+      ? createPlaceholderConversation({
+          id: conversationId,
+          name: fallbackName,
+          avatarUrl: fallbackAvatar,
+        })
+      : undefined)
+
+  if (!conversation) {
+    notFound()
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 lg:flex-row lg:py-16">
+        <div className="w-full overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60 shadow-2xl backdrop-blur lg:flex lg:max-w-sm">
+          <ConversationList activeConversationId={conversation.id} className="hidden lg:flex" />
+          <div className="flex flex-col gap-4 p-6 lg:hidden">
+            <h1 className="text-xl font-semibold">แชท</h1>
+            <p className="text-sm text-slate-400">
+              เลือกรายชื่อจากหน้า <Link href="/chat" className="text-blue-300 underline underline-offset-4">กล่องข้อความ</Link> เพื่อดูบทสนทนาทั้งหมด
+            </p>
+          </div>
+        </div>
+
+        <section className="flex w-full flex-1 flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 shadow-2xl backdrop-blur">
+          <header className="flex flex-col gap-4 border-b border-white/5 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-4">
+              <Link
+                href="/chat"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-slate-300 transition hover:border-blue-500/40 hover:text-white sm:hidden"
+                aria-label="กลับไปยังรายชื่อแชท"
+              >
+                <ArrowLeft className="h-5 w-5" />
+              </Link>
+              <Avatar className="h-14 w-14">
+                <AvatarImage src={conversation.avatarUrl} alt={conversation.name} />
+                <AvatarFallback className="bg-blue-500/20 text-lg text-blue-100">
+                  {conversation.name
+                    .split(" ")
+                    .map((segment) => segment.charAt(0))
+                    .join("")
+                    .slice(0, 2)
+                    .toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <h2 className="text-lg font-semibold text-white">{conversation.name}</h2>
+                  <span className="rounded-full bg-emerald-500/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-200">
+                    {conversation.isOnline ? "ออนไลน์" : "ออฟไลน์"}
+                  </span>
+                </div>
+                <p className="text-sm text-slate-400">ผู้ซื้อ: {conversation.buyerName}</p>
+                {conversation.location && (
+                  <p className="text-xs text-slate-500">ทำเล: {conversation.location}</p>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                className="inline-flex h-10 items-center gap-2 rounded-full border border-white/10 px-4 text-sm font-medium text-slate-200 transition hover:border-blue-500/40 hover:text-white"
+              >
+                <Phone className="h-4 w-4" />
+                โทรหา
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-10 items-center gap-2 rounded-full border border-white/10 px-4 text-sm font-medium text-slate-200 transition hover:border-blue-500/40 hover:text-white"
+              >
+                <Video className="h-4 w-4" />
+                วิดีโอคอล
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-10 items-center justify-center rounded-full border border-white/10 px-4 text-sm text-slate-200 transition hover:border-blue-500/40 hover:text-white"
+                aria-label="ข้อมูลเพิ่มเติม"
+              >
+                <Info className="h-4 w-4" />
+              </button>
+            </div>
+          </header>
+
+          <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-6 py-8">
+            {conversation.messages.map((message: ChatMessage) => (
+              <div
+                key={message.id}
+                className={cn("flex w-full", message.author === "buyer" ? "justify-end" : "justify-start")}
+              >
+                <div
+                  className={cn(
+                    "max-w-xl rounded-3xl px-5 py-3 text-sm shadow-xl",
+                    message.author === "buyer"
+                      ? "bg-blue-500/90 text-white"
+                      : "bg-white/10 text-slate-100",
+                  )}
+                >
+                  <p className="leading-relaxed">{message.text}</p>
+                  <span className="mt-2 block text-right text-[11px] uppercase tracking-wide text-slate-300/80">
+                    {message.time}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <footer className="border-t border-white/5 bg-slate-900/70 p-6">
+            <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/60 p-4 shadow-inner shadow-slate-900/40 sm:flex-row sm:items-center">
+              <button
+                type="button"
+                className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 text-sm text-slate-200 transition hover:border-blue-500/40 hover:text-white sm:w-auto sm:px-4"
+              >
+                <Image className="h-4 w-4" />
+                แนบรูปทรัพย์สิน
+              </button>
+              <div className="flex flex-1 items-center gap-3 rounded-xl border border-white/10 bg-slate-900/80 px-4">
+                <input
+                  type="text"
+                  placeholder={`พิมพ์ข้อความเพื่อคุยกับ ${conversation.name}`}
+                  className="h-11 flex-1 bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-500 text-white shadow-lg shadow-blue-500/30 transition hover:bg-blue-600"
+                  aria-label="ส่งข้อความ"
+                >
+                  <Send className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="hidden min-w-[180px] flex-col gap-1 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-xs text-slate-300 sm:flex">
+                <div className="flex items-center gap-2 text-slate-200">
+                  <Home className="h-4 w-4" />
+                  รายละเอียดประกาศ
+                </div>
+                {conversation.propertySummary && (
+                  <p className="text-slate-400">{conversation.propertySummary}</p>
+                )}
+                {conversation.askingPrice && (
+                  <p className="font-semibold text-white">ราคาเสนอ {conversation.askingPrice}</p>
+                )}
+              </div>
+            </div>
+          </footer>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next"
+
+import { ConversationList } from "@/components/chat/conversation-list"
+
+export const metadata: Metadata = {
+  title: "กล่องข้อความ | DreamHome",
+  description: "จัดการการสนทนาระหว่างผู้ซื้อและผู้ขายบน DreamHome ในที่เดียว",
+}
+
+export default function ChatPage() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-10 lg:py-16">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/70 shadow-2xl backdrop-blur">
+          <ConversationList />
+        </div>
+        <div className="rounded-3xl border border-dashed border-white/10 bg-slate-900/40 p-8 text-center">
+          <h2 className="text-lg font-semibold text-white">เลือกการสนทนาที่ต้องการทางด้านบน</h2>
+          <p className="mt-2 text-sm text-slate-400">
+            เมื่อเลือกรายชื่อผู้ติดต่อ เราจะแสดงรายละเอียดบทสนทนาและข้อมูลอสังหาฯ ที่เกี่ยวข้องให้คุณทันที
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,7 +78,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               />
 
               <ChatPanelProvider>
-                <div className="min-h-screen lg:flex lg:items-stretch">
+                <div
+                  className="min-h-screen lg:flex lg:items-stretch lg:[--chat-panel-gutter:1.5rem] lg:[--chat-panel-width:clamp(20rem,28vw,28rem)]"
+                >
                   <ChatPanelOffsetContainer>
                     <Navigation />
                     <main className="flex-1">{children}</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,12 +78,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               />
 
               <ChatPanelProvider>
-                <ChatPanelOffsetContainer>
-                  <Navigation />
-                  <main className="flex-1">{children}</main>
-                  <Footer />
-                </ChatPanelOffsetContainer>
-                <ChatPanel />
+                <div className="min-h-screen lg:flex lg:items-stretch">
+                  <ChatPanelOffsetContainer>
+                    <Navigation />
+                    <main className="flex-1">{children}</main>
+                    <Footer />
+                  </ChatPanelOffsetContainer>
+                  <ChatPanel />
+                </div>
               </ChatPanelProvider>
               <Toaster />
             </AuthProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,8 @@ import "./globals.css";
 import ClientOnly from "@/components/ClientOnly";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ChatPanelProvider } from "@/contexts/chat-panel-context";
+import { ChatPanelOffsetContainer } from "@/components/chat-panel-offset-container";
 import { Toaster } from "@/components/ui/toaster";
 import Navigation from "@/components/navigation";
 import Footer from "@/components/footer";
@@ -74,11 +76,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 aria-hidden="true"
               />
 
-              <div className="min-h-screen flex flex-col">
-                <Navigation />
-                <main className="flex-1">{children}</main>
-                <Footer />
-              </div>
+              <ChatPanelProvider>
+                <ChatPanelOffsetContainer>
+                  <Navigation />
+                  <main className="flex-1">{children}</main>
+                  <Footer />
+                </ChatPanelOffsetContainer>
+              </ChatPanelProvider>
               <Toaster />
             </AuthProvider>
           </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ChatPanelProvider } from "@/contexts/chat-panel-context";
 import { ChatPanelOffsetContainer } from "@/components/chat-panel-offset-container";
+import { ChatPanel } from "@/components/chat-panel";
 import { Toaster } from "@/components/ui/toaster";
 import Navigation from "@/components/navigation";
 import Footer from "@/components/footer";
@@ -82,6 +83,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <main className="flex-1">{children}</main>
                   <Footer />
                 </ChatPanelOffsetContainer>
+                <ChatPanel />
               </ChatPanelProvider>
               <Toaster />
             </AuthProvider>

--- a/app/users/[uid]/page.tsx
+++ b/app/users/[uid]/page.tsx
@@ -1,9 +1,13 @@
 import { UserProfilePage } from "@/components/user-profile-page";
 
 interface UserProfileRouteProps {
-  params: { uid: string };
+  params: Promise<{ uid: string }>;
 }
 
-export default function UserProfileRoute({ params }: UserProfileRouteProps) {
-  return <UserProfilePage uid={params.uid} />;
+export default async function UserProfileRoute({
+  params,
+}: UserProfileRouteProps) {
+  const { uid } = await params;
+
+  return <UserProfilePage uid={uid} />;
 }

--- a/components/chat-panel-offset-container.tsx
+++ b/components/chat-panel-offset-container.tsx
@@ -2,12 +2,6 @@
 
 import type { ReactNode } from "react";
 
-import {
-  CHAT_PANEL_PADDING_CLASS,
-  useChatPanel,
-} from "@/contexts/chat-panel-context";
-import { cn } from "@/lib/utils";
-
 interface ChatPanelOffsetContainerProps {
   children: ReactNode;
 }
@@ -15,15 +9,8 @@ interface ChatPanelOffsetContainerProps {
 export function ChatPanelOffsetContainer({
   children,
 }: ChatPanelOffsetContainerProps): JSX.Element {
-  const { isOpen } = useChatPanel();
-
   return (
-    <div
-      className={cn(
-        "min-h-screen flex flex-col transition-[padding] duration-300 ease-in-out",
-        isOpen ? CHAT_PANEL_PADDING_CLASS : undefined,
-      )}
-    >
+    <div className="flex min-h-screen flex-1 flex-col bg-background transition-[max-width] duration-300 ease-in-out">
       {children}
     </div>
   );

--- a/components/chat-panel-offset-container.tsx
+++ b/components/chat-panel-offset-container.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import {
+  CHAT_PANEL_PADDING_CLASS,
+  useChatPanel,
+} from "@/contexts/chat-panel-context";
+import { cn } from "@/lib/utils";
+
+interface ChatPanelOffsetContainerProps {
+  children: ReactNode;
+}
+
+export function ChatPanelOffsetContainer({
+  children,
+}: ChatPanelOffsetContainerProps): JSX.Element {
+  const { isOpen } = useChatPanel();
+
+  return (
+    <div
+      className={cn(
+        "min-h-screen flex flex-col transition-[padding] duration-300 ease-in-out",
+        isOpen ? CHAT_PANEL_PADDING_CLASS : undefined,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -6,6 +6,7 @@ import { X } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { useChatPanel } from "@/contexts/chat-panel-context";
 import { cn } from "@/lib/utils";
 
@@ -47,6 +48,13 @@ export function ChatPanel(): JSX.Element {
   const activeParticipant = participant ?? DEFAULT_PARTICIPANT;
   const [messages, setMessages] = useState<ChatMessage[]>(defaultMessages);
   const [message, setMessage] = useState("");
+  const [isLargeScreen, setIsLargeScreen] = useState(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+
+    return window.matchMedia("(min-width: 1024px)").matches;
+  });
 
   useEffect(() => {
     if (!isOpen) {
@@ -57,6 +65,32 @@ export function ChatPanel(): JSX.Element {
   useEffect(() => {
     setMessages(defaultMessages);
   }, [activeParticipant.name]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
+
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      setIsLargeScreen(event.matches);
+    };
+
+    handleChange(mediaQuery);
+
+    const listener = (event: MediaQueryListEvent) => handleChange(event);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", listener);
+
+      return () => {
+        mediaQuery.removeEventListener("change", listener);
+      };
+    }
+
+    mediaQuery.addListener(listener);
+
+    return () => {
+      mediaQuery.removeListener(listener);
+    };
+  }, []);
 
   useEffect(() => {
     if (!isOpen) {
@@ -106,115 +140,124 @@ export function ChatPanel(): JSX.Element {
     setMessage("");
   };
 
-  return (
-    <>
-      <div
-        role="presentation"
-        aria-hidden="true"
-        onClick={close}
-        className={cn(
-          "fixed inset-0 z-30 bg-background/80 backdrop-blur-sm transition-opacity duration-300 lg:hidden",
-          isOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
-        )}
-      />
-
-      <aside
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="global-chat-panel-title"
-        className={cn(
-          "fixed inset-y-0 right-0 z-40 flex w-full max-w-md flex-col border-l bg-background shadow-xl transition-transform duration-300 ease-in-out",
-          isOpen ? "translate-x-0 pointer-events-auto" : "translate-x-full pointer-events-none",
-          "lg:sticky lg:top-0 lg:z-auto lg:h-screen lg:max-w-[var(--chat-panel-width,28rem)] lg:w-[var(--chat-panel-width,28rem)] lg:translate-x-0 lg:border-l lg:shadow-none lg:pointer-events-auto lg:left-auto lg:right-auto lg:bottom-auto",
-          !isOpen && "lg:hidden",
-        )}
-      >
-        <header className="flex items-center justify-between border-b p-4">
-          <div className="flex items-center gap-3">
-            <Avatar className="h-10 w-10">
-              <AvatarImage src={activeParticipant.avatarUrl ?? ""} alt={activeParticipant.name} />
-              <AvatarFallback className="font-semibold">
-                {participantInitials}
-              </AvatarFallback>
-            </Avatar>
-            <div className="space-y-1">
-              <p id="global-chat-panel-title" className="text-sm font-semibold text-foreground">
-                แชทกับ {activeParticipant.name}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                พูดคุยรายละเอียดเกี่ยวกับการซื้อบ้านแบบตัวต่อตัวกับผู้เชี่ยวชาญ
-              </p>
-            </div>
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={close}
-            aria-label="ปิดหน้าต่างแชท"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </header>
-
-        <div className="flex flex-1 flex-col gap-4 p-4">
-          <div className="flex-1 space-y-3 overflow-y-auto pr-1 text-sm">
-            {messages.map((chat) => (
-              <div
-                key={chat.id}
-                className={cn(
-                  "flex",
-                  chat.sender === "buyer" ? "justify-end" : "justify-start",
-                )}
-              >
-                <div
-                  className={cn(
-                    "max-w-[80%] rounded-2xl px-4 py-2 shadow-sm",
-                    chat.sender === "buyer"
-                      ? "bg-blue-600 text-white"
-                      : "bg-white text-foreground",
-                  )}
-                >
-                  <p className="leading-relaxed">{chat.text}</p>
-                  <span
-                    className={cn(
-                      "mt-1 block text-[10px] font-medium uppercase tracking-wide",
-                      chat.sender === "buyer"
-                        ? "text-blue-100"
-                        : "text-muted-foreground",
-                    )}
-                  >
-                    {chat.timestamp}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
-            <p className="font-medium">
-              ข้อแนะนำ: ปรึกษารายละเอียดสัญญาและการโอนกับผู้เชี่ยวชาญก่อนตัดสินใจ
+  const panelContent = (
+    <div className="flex h-full flex-col">
+      <header className="flex items-center justify-between border-b p-4">
+        <div className="flex items-center gap-3">
+          <Avatar className="h-10 w-10">
+            <AvatarImage src={activeParticipant.avatarUrl ?? ""} alt={activeParticipant.name} />
+            <AvatarFallback className="font-semibold">
+              {participantInitials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="space-y-1">
+            <p id="global-chat-panel-title" className="text-sm font-semibold text-foreground">
+              แชทกับ {activeParticipant.name}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              พูดคุยรายละเอียดเกี่ยวกับการซื้อบ้านแบบตัวต่อตัวกับผู้เชี่ยวชาญ
             </p>
           </div>
         </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={close}
+          aria-label="ปิดหน้าต่างแชท"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </header>
 
-        <footer className="border-t bg-muted/10 p-4">
-          <div className="flex items-center gap-2">
-            <Input
-              value={message}
-              placeholder="พิมพ์ข้อความถึงผู้ขาย..."
-              onChange={(event) => setMessage(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  handleSendMessage();
-                }
-              }}
-            />
-            <Button type="button" onClick={handleSendMessage}>
-              ส่งข้อความ
-            </Button>
-          </div>
-        </footer>
-      </aside>
-    </>
+      <div className="flex flex-1 flex-col gap-4 p-4">
+        <div className="flex-1 space-y-3 overflow-y-auto pr-1 text-sm">
+          {messages.map((chat) => (
+            <div
+              key={chat.id}
+              className={cn(
+                "flex",
+                chat.sender === "buyer" ? "justify-end" : "justify-start",
+              )}
+            >
+              <div
+                className={cn(
+                  "max-w-[80%] rounded-2xl px-4 py-2 shadow-sm",
+                  chat.sender === "buyer"
+                    ? "bg-blue-600 text-white"
+                    : "bg-white text-foreground",
+                )}
+              >
+                <p className="leading-relaxed">{chat.text}</p>
+                <span
+                  className={cn(
+                    "mt-1 block text-[10px] font-medium uppercase tracking-wide",
+                    chat.sender === "buyer"
+                      ? "text-blue-100"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {chat.timestamp}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+          <p className="font-medium">
+            ข้อแนะนำ: ปรึกษารายละเอียดสัญญาและการโอนกับผู้เชี่ยวชาญก่อนตัดสินใจ
+          </p>
+        </div>
+      </div>
+
+      <footer className="border-t bg-muted/10 p-4">
+        <div className="flex items-center gap-2">
+          <Input
+            value={message}
+            placeholder="พิมพ์ข้อความถึงผู้ขาย..."
+            onChange={(event) => setMessage(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                handleSendMessage();
+              }
+            }}
+          />
+          <Button type="button" onClick={handleSendMessage}>
+            ส่งข้อความ
+          </Button>
+        </div>
+      </footer>
+    </div>
+  );
+
+  if (!isLargeScreen) {
+    return (
+      <Sheet open={isOpen} onOpenChange={(open) => (!open ? close() : undefined)}>
+        <SheetContent
+          side="right"
+          className="flex h-full w-full max-w-md flex-col border-l border-border bg-background p-0 shadow-xl"
+          titleText="หน้าต่างแชท"
+          showCloseButton={false}
+          aria-labelledby="global-chat-panel-title"
+        >
+          {panelContent}
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <aside
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="global-chat-panel-title"
+      className="sticky top-0 z-30 flex h-screen max-w-[var(--chat-panel-width,28rem)] w-[var(--chat-panel-width,28rem)] flex-col border-l border-border bg-background"
+    >
+      {panelContent}
+    </aside>
   );
 }

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -125,7 +125,7 @@ export function ChatPanel(): JSX.Element {
         className={cn(
           "fixed inset-y-0 right-0 z-40 flex w-full max-w-md flex-col border-l bg-background shadow-xl transition-transform duration-300 ease-in-out",
           isOpen ? "translate-x-0 pointer-events-auto" : "translate-x-full pointer-events-none",
-          "lg:sticky lg:top-0 lg:z-auto lg:h-screen lg:max-w-none lg:w-[28rem] lg:translate-x-0 lg:border-l lg:shadow-none lg:pointer-events-auto lg:left-auto lg:right-auto lg:bottom-auto",
+          "lg:sticky lg:top-0 lg:z-auto lg:h-screen lg:max-w-[var(--chat-panel-width,28rem)] lg:w-[var(--chat-panel-width,28rem)] lg:translate-x-0 lg:border-l lg:shadow-none lg:pointer-events-auto lg:left-auto lg:right-auto lg:bottom-auto",
           !isOpen && "lg:hidden",
         )}
       >

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -123,9 +123,10 @@ export function ChatPanel(): JSX.Element {
         aria-modal="true"
         aria-labelledby="global-chat-panel-title"
         className={cn(
-          "fixed inset-y-0 right-0 z-40 flex w-full max-w-md flex-col border-l bg-background shadow-xl transition-transform duration-300 ease-in-out lg:max-w-none lg:w-[28rem]",
-          isOpen ? "translate-x-0" : "translate-x-full",
-          isOpen ? "pointer-events-auto" : "pointer-events-none",
+          "fixed inset-y-0 right-0 z-40 flex w-full max-w-md flex-col border-l bg-background shadow-xl transition-transform duration-300 ease-in-out",
+          isOpen ? "translate-x-0 pointer-events-auto" : "translate-x-full pointer-events-none",
+          "lg:sticky lg:top-0 lg:z-auto lg:h-screen lg:max-w-none lg:w-[28rem] lg:translate-x-0 lg:border-l lg:shadow-none lg:pointer-events-auto lg:left-auto lg:right-auto lg:bottom-auto",
+          !isOpen && "lg:hidden",
         )}
       >
         <header className="flex items-center justify-between border-b p-4">

--- a/components/chat-widget.tsx
+++ b/components/chat-widget.tsx
@@ -5,9 +5,16 @@ import type React from "react"
 import { useState } from "react"
 import { MessageCircle, X, Send, Bot } from "lucide-react"
 
+import {
+  CHAT_WIDGET_OFFSET_CLASS,
+  useChatPanel,
+} from "@/contexts/chat-panel-context"
+import { cn } from "@/lib/utils"
+
 export default function ChatWidget() {
   const [isOpen, setIsOpen] = useState(false)
   const [message, setMessage] = useState("")
+  const { isOpen: isChatPanelOpen } = useChatPanel()
 
   const toggleChat = () => {
     setIsOpen(!isOpen)
@@ -29,7 +36,12 @@ export default function ChatWidget() {
   return (
     <>
       {/* Chat Button */}
-      <div className="fixed bottom-6 right-6 z-40">
+      <div
+        className={cn(
+          "fixed bottom-6 right-6 z-40 transition-[right] duration-300 ease-in-out",
+          isChatPanelOpen ? CHAT_WIDGET_OFFSET_CLASS : undefined,
+        )}
+      >
         <button
           onClick={toggleChat}
           className="bg-blue-600 text-white p-4 rounded-full shadow-lg hover:bg-blue-700 transition-all duration-300 animate-bounce"

--- a/components/chat-widget.tsx
+++ b/components/chat-widget.tsx
@@ -1,9 +1,6 @@
 "use client"
 
-import type React from "react"
-
-import { useState } from "react"
-import { MessageCircle, X, Send, Bot } from "lucide-react"
+import { MessageCircle } from "lucide-react"
 
 import {
   CHAT_WIDGET_OFFSET_CLASS,
@@ -12,89 +9,38 @@ import {
 import { cn } from "@/lib/utils"
 
 export default function ChatWidget() {
-  const [isOpen, setIsOpen] = useState(false)
-  const [message, setMessage] = useState("")
-  const { isOpen: isChatPanelOpen } = useChatPanel()
+  const { isOpen, openWith, close } = useChatPanel()
 
-  const toggleChat = () => {
-    setIsOpen(!isOpen)
-  }
-
-  const handleSendMessage = () => {
-    if (message.trim()) {
-      // Handle message sending logic here
-      setMessage("")
+  const handleClick = () => {
+    if (isOpen) {
+      close()
+      return
     }
-  }
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      handleSendMessage()
-    }
+    openWith({
+      name: "DreamHome Assistant",
+      avatarUrl: "",
+    })
   }
 
   return (
-    <>
-      {/* Chat Button */}
-      <div
-        className={cn(
-          "fixed bottom-6 right-6 z-40 transition-[right] duration-300 ease-in-out",
-          isChatPanelOpen ? CHAT_WIDGET_OFFSET_CLASS : undefined,
-        )}
-      >
-        <button
-          onClick={toggleChat}
-          className="bg-blue-600 text-white p-4 rounded-full shadow-lg hover:bg-blue-700 transition-all duration-300 animate-bounce"
-        >
-          <MessageCircle size={24} />
-        </button>
-      </div>
-
-      {/* Chat Widget */}
-      {isOpen && (
-        <div className="fixed bottom-20 sm:bottom-24 right-2 sm:right-6 w-72 sm:w-80 bg-white rounded-lg shadow-2xl z-50 max-h-96 sm:max-h-none">
-          <div className="bg-blue-600 text-white p-3 sm:p-4 rounded-t-lg">
-            <div className="flex justify-between items-center">
-              <h3 className="font-semibold text-sm sm:text-base">แชทสดช่วยเหลือ</h3>
-              <button onClick={toggleChat} className="text-white hover:text-gray-200 transition-colors">
-                <X size={18} />
-              </button>
-            </div>
-          </div>
-          <div className="p-3 sm:p-4 h-48 sm:h-64 overflow-y-auto">
-            <div className="space-y-3 sm:space-y-4">
-              <div className="flex items-start space-x-2">
-                <div className="w-7 sm:w-8 h-7 sm:h-8 bg-blue-600 rounded-full flex items-center justify-center flex-shrink-0">
-                  <Bot className="text-white" size={14} />
-                </div>
-                <div className="bg-gray-100 p-2 sm:p-3 rounded-lg max-w-xs">
-                  <p className="text-xs sm:text-sm text-gray-900 font-medium">
-                    สวัสดี! ฉันสามารถช่วยคุณค้นหาอสังหาริมทรัพย์ในฝันได้อย่างไร?
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="p-3 sm:p-4 border-t">
-            <div className="flex space-x-2">
-              <input
-                type="text"
-                placeholder="พิมพ์ข้อความของคุณ..."
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                onKeyPress={handleKeyPress}
-                className="flex-1 px-2 sm:px-3 py-2 border rounded-lg text-xs sm:text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none text-gray-900 font-medium placeholder:text-gray-500"
-              />
-              <button
-                onClick={handleSendMessage}
-                className="bg-blue-600 text-white px-3 sm:px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors font-semibold"
-              >
-                <Send size={14} />
-              </button>
-            </div>
-          </div>
-        </div>
+    <div
+      className={cn(
+        "fixed bottom-6 right-6 z-40 transition-[right] duration-300 ease-in-out",
+        isOpen ? CHAT_WIDGET_OFFSET_CLASS : undefined,
       )}
-    </>
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        className={cn(
+          "rounded-full bg-blue-600 p-4 text-white shadow-lg transition-all duration-300 hover:bg-blue-700",
+          !isOpen && "animate-bounce",
+        )}
+        aria-label={isOpen ? "ปิดหน้าต่างแชท" : "เปิดหน้าต่างแชท"}
+      >
+        <MessageCircle size={24} />
+      </button>
+    </div>
   )
 }

--- a/components/chat/conversation-list.tsx
+++ b/components/chat/conversation-list.tsx
@@ -1,0 +1,151 @@
+import Link from "next/link"
+import { MessageSquare, Plus, Search } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { getConversationSummaries } from "@/lib/mock-chats"
+
+const filters = [
+  { key: "all", label: "ทั้งหมด" },
+  { key: "unread", label: "ยังไม่ได้อ่าน" },
+  { key: "group", label: "กลุ่ม" },
+]
+
+interface ConversationListProps {
+  activeConversationId?: string
+  className?: string
+}
+
+export function ConversationList({
+  activeConversationId,
+  className,
+}: ConversationListProps) {
+  const conversations = getConversationSummaries()
+
+  return (
+    <section
+      className={cn(
+        "flex h-full flex-col gap-6 bg-slate-950/80 p-6 text-slate-100",
+        "lg:min-h-[720px]",
+        className,
+      )}
+    >
+      <header className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">แชท</h1>
+            <p className="text-sm text-slate-400">พูดคุยกับผู้ซื้อและผู้ขายแบบเรียลไทม์</p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-500/90 text-white shadow-lg shadow-blue-500/30 transition hover:bg-blue-500"
+            aria-label="เริ่มแชทใหม่"
+          >
+            <Plus className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400">
+            <Search className="h-4 w-4" />
+          </div>
+          <input
+            type="search"
+            placeholder="ค้นหาในแชท"
+            className="h-11 w-full rounded-2xl border border-white/5 bg-white/5 pl-10 pr-4 text-sm text-slate-100 placeholder:text-slate-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/60"
+            aria-label="ค้นหาในแชท"
+          />
+        </div>
+
+        <div className="flex gap-2">
+          {filters.map((filter) => (
+            <button
+              key={filter.key}
+              type="button"
+              className={cn(
+                "flex flex-1 items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm font-medium transition",
+                filter.key === "all"
+                  ? "bg-white/10 text-white"
+                  : "bg-transparent text-slate-300 hover:bg-white/10 hover:text-white",
+              )}
+            >
+              {filter.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="space-y-2">
+        {conversations.map((conversation) => {
+          const isActive = conversation.id === activeConversationId
+
+          return (
+            <Link
+              key={conversation.id}
+              href={`/chat/${conversation.id}`}
+              className={cn(
+                "group flex items-center gap-3 rounded-2xl border border-transparent px-3 py-3 transition",
+                isActive
+                  ? "border-blue-500/60 bg-blue-500/15 text-white"
+                  : "bg-white/5 hover:border-white/10 hover:bg-white/10",
+              )}
+            >
+              <div className="relative">
+                <span className="inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-full bg-slate-800">
+                  <img
+                    src={conversation.avatarUrl}
+                    alt={conversation.name}
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                  />
+                </span>
+                {conversation.isOnline && (
+                  <span className="absolute -bottom-1 -right-1 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border-2 border-slate-950/90 bg-emerald-400" />
+                )}
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start gap-2">
+                  <p className="truncate text-sm font-medium text-white">
+                    {conversation.name}
+                  </p>
+                  {conversation.badge && (
+                    <span className="inline-flex shrink-0 items-center rounded-full bg-blue-500/20 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-200">
+                      {conversation.badge}
+                    </span>
+                  )}
+                </div>
+                <p className="truncate text-sm text-slate-400">
+                  {conversation.preview}
+                </p>
+                {conversation.propertySummary && (
+                  <p className="mt-1 truncate text-xs text-slate-500">
+                    {conversation.propertySummary}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-col items-end gap-2 text-right text-xs text-slate-400">
+                <span>{conversation.lastActive}</span>
+                {conversation.unreadCount ? (
+                  <span className="inline-flex min-w-[1.75rem] items-center justify-center rounded-full bg-blue-500/90 px-2 py-0.5 text-[11px] font-semibold text-white">
+                    {conversation.unreadCount}
+                  </span>
+                ) : (
+                  <MessageSquare className="h-4 w-4 text-slate-600 group-hover:text-slate-300" />
+                )}
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+
+      <footer className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-sm text-slate-300">
+        <span>ดูทั้งหมดใน DreamHome Chat</span>
+        <span className="text-xs text-slate-500">อัปเดตล่าสุด {new Date().toLocaleTimeString("th-TH", {
+          hour: "2-digit",
+          minute: "2-digit",
+        })}</span>
+      </footer>
+    </section>
+  )
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -3,7 +3,7 @@
 import type React from "react"
 import { useEffect, useState } from "react"
 import Link from "next/link"
-import { usePathname, useRouter } from "next/navigation"
+import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -39,15 +39,15 @@ import {
 import SignInModal from "./sign-in-modal"
 import SignUpModal from "./sign-up-modal"
 import { useAuthContext } from "@/contexts/AuthContext"
+import { useChatPanel } from "@/contexts/chat-panel-context"
 import { useToast } from "@/hooks/use-toast"
 import { ToastAction } from "@/components/ui/toast"
 
 const Navigation: React.FC = () => {
   const { user, loading, signOut } = useAuthContext()
+  const { open, openWith, participant } = useChatPanel()
   const { toast } = useToast()
   const pathname = usePathname()
-
-  const router = useRouter()
 
   const [isSignInOpen, setIsSignInOpen] = useState(false)
   const [isSignUpOpen, setIsSignUpOpen] = useState(false)
@@ -131,6 +131,18 @@ const Navigation: React.FC = () => {
   const switchToSignIn = () => {
     setIsSignUpOpen(false)
     setIsSignInOpen(true)
+  }
+
+  const handleOpenChat = () => {
+    if (participant) {
+      open()
+      return
+    }
+
+    openWith({
+      name: "DreamHome Assistant",
+      avatarUrl: "",
+    })
   }
 
   return (
@@ -255,7 +267,12 @@ const Navigation: React.FC = () => {
                         <User className="mr-2 h-4 w-4" />
                         <span>โปรไฟล์</span>
                       </DropdownMenuItem>
-                      <DropdownMenuItem onSelect={() => router.push("/chat")}>
+                      <DropdownMenuItem
+                        onSelect={(event) => {
+                          event.preventDefault()
+                          handleOpenChat()
+                        }}
+                      >
                         <Mail className="mr-2 h-4 w-4" />
                         <span>ข้อความ</span>
                       </DropdownMenuItem>

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -39,14 +39,11 @@ import {
 import SignInModal from "./sign-in-modal"
 import SignUpModal from "./sign-up-modal"
 import { useAuthContext } from "@/contexts/AuthContext"
-import { useChatPanel, CHAT_PANEL_PADDING_CLASS } from "@/contexts/chat-panel-context"
 import { useToast } from "@/hooks/use-toast"
 import { ToastAction } from "@/components/ui/toast"
-import { cn } from "@/lib/utils"
 
 const Navigation: React.FC = () => {
   const { user, loading, signOut } = useAuthContext()
-  const { isOpen: isChatPanelOpen } = useChatPanel()
   const { toast } = useToast()
   const pathname = usePathname()
 
@@ -136,12 +133,7 @@ const Navigation: React.FC = () => {
 
   return (
     <>
-      <nav
-        className={cn(
-          "sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 transition-[padding] duration-300 ease-in-out",
-          isChatPanelOpen ? CHAT_PANEL_PADDING_CLASS : undefined,
-        )}
-      >
+      <nav className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
         <div className="container mx-auto px-4">
           <div className="flex h-14 sm:h-16 w-full items-center">
             {/* Logo */}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -39,11 +39,14 @@ import {
 import SignInModal from "./sign-in-modal"
 import SignUpModal from "./sign-up-modal"
 import { useAuthContext } from "@/contexts/AuthContext"
+import { useChatPanel, CHAT_PANEL_PADDING_CLASS } from "@/contexts/chat-panel-context"
 import { useToast } from "@/hooks/use-toast"
 import { ToastAction } from "@/components/ui/toast"
+import { cn } from "@/lib/utils"
 
 const Navigation: React.FC = () => {
   const { user, loading, signOut } = useAuthContext()
+  const { isOpen: isChatPanelOpen } = useChatPanel()
   const { toast } = useToast()
   const pathname = usePathname()
 
@@ -133,7 +136,12 @@ const Navigation: React.FC = () => {
 
   return (
     <>
-      <nav className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+      <nav
+        className={cn(
+          "sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60 transition-[padding] duration-300 ease-in-out",
+          isChatPanelOpen ? CHAT_PANEL_PADDING_CLASS : undefined,
+        )}
+      >
         <div className="container mx-auto px-4">
           <div className="flex h-14 sm:h-16 w-full items-center">
             {/* Logo */}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -3,7 +3,7 @@
 import type React from "react"
 import { useEffect, useState } from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -46,6 +46,8 @@ const Navigation: React.FC = () => {
   const { user, loading, signOut } = useAuthContext()
   const { toast } = useToast()
   const pathname = usePathname()
+
+  const router = useRouter()
 
   const [isSignInOpen, setIsSignInOpen] = useState(false)
   const [isSignUpOpen, setIsSignUpOpen] = useState(false)
@@ -253,7 +255,7 @@ const Navigation: React.FC = () => {
                         <User className="mr-2 h-4 w-4" />
                         <span>โปรไฟล์</span>
                       </DropdownMenuItem>
-                      <DropdownMenuItem>
+                      <DropdownMenuItem onSelect={() => router.push("/chat")}>
                         <Mail className="mr-2 h-4 w-4" />
                         <span>ข้อความ</span>
                       </DropdownMenuItem>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-white/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -56,6 +56,7 @@ interface SheetContentProps
    * มีไว้เพื่อป้องกัน Radix เตือนเรื่อง a11y
    */
   titleText?: string
+  showCloseButton?: boolean
 }
 
 function containsTitle(node: React.ReactNode): boolean {
@@ -82,7 +83,18 @@ function containsTitle(node: React.ReactNode): boolean {
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, titleText = "Panel", ...props }, ref) => {
+>(
+  (
+    {
+      side = "right",
+      className,
+      children,
+      titleText = "Panel",
+      showCloseButton = true,
+      ...props
+    },
+    ref
+  ) => {
   const hasTitle = React.useMemo(() => containsTitle(children), [children])
 
   return (
@@ -102,14 +114,17 @@ const SheetContent = React.forwardRef<
 
         {children}
 
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
       </SheetPrimitive.Content>
     </SheetPortal>
   )
-})
+}
+)
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({

--- a/components/user-chat-dialog.tsx
+++ b/components/user-chat-dialog.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface UserChatDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  participantName: string;
+  participantAvatar?: string;
+}
+
+interface ChatMessage {
+  id: number;
+  sender: "buyer" | "seller";
+  text: string;
+  timestamp: string;
+}
+
+const initialMessages: ChatMessage[] = [
+  {
+    id: 1,
+    sender: "seller",
+    text: "สวัสดีค่ะ บ้านหลังนี้ยังว่างอยู่ สนใจรายละเอียดเพิ่มเติมไหมคะ?",
+    timestamp: "09:15",
+  },
+  {
+    id: 2,
+    sender: "buyer",
+    text: "สนใจค่ะ อยากทราบว่ามีส่วนลดพิเศษสำหรับการโอนภายในเดือนนี้ไหมครับ",
+    timestamp: "09:17",
+  },
+  {
+    id: 3,
+    sender: "seller",
+    text: "มีค่ะ หากโอนภายในเดือนนี้สามารถลดได้อีก 50,000 บาท พร้อมของแถมเครื่องปรับอากาศ",
+    timestamp: "09:18",
+  },
+];
+
+export function UserChatDialog({
+  open,
+  onOpenChange,
+  participantName,
+  participantAvatar,
+}: UserChatDialogProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
+  const [message, setMessage] = useState("");
+
+  const participantInitials = useMemo(() => {
+    return participantName
+      .split(" ")
+      .map((segment) => segment.charAt(0))
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }, [participantName]);
+
+  const handleSendMessage = () => {
+    if (!message.trim()) {
+      return;
+    }
+
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: prev.length + 1,
+        sender: "buyer",
+        text: message.trim(),
+        timestamp: new Date().toLocaleTimeString("th-TH", {
+          hour: "2-digit",
+          minute: "2-digit",
+        }),
+      },
+    ]);
+    setMessage("");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader className="space-y-3">
+          <DialogTitle>แชทกับ {participantName}</DialogTitle>
+          <DialogDescription>
+            พูดคุยรายละเอียดเกี่ยวกับการซื้อบ้านแบบตัวต่อตัวกับผู้ขายรายนี้
+          </DialogDescription>
+          <div className="flex items-center gap-3 rounded-lg bg-muted/50 p-3">
+            <Avatar className="h-12 w-12">
+              <AvatarImage src={participantAvatar ?? ""} alt={participantName} />
+              <AvatarFallback className="font-semibold">
+                {participantInitials}
+              </AvatarFallback>
+            </Avatar>
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                {participantName}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                ตอบกลับโดยเฉลี่ยภายใน 30 นาที
+              </p>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="flex h-72 flex-col gap-4 rounded-lg border bg-muted/30 p-4">
+          <div className="flex-1 space-y-3 overflow-y-auto pr-1 text-sm">
+            {messages.map((chat) => (
+              <div
+                key={chat.id}
+                className={`flex ${
+                  chat.sender === "buyer" ? "justify-end" : "justify-start"
+                }`}
+              >
+                <div
+                  className={`max-w-[80%] rounded-2xl px-4 py-2 shadow-sm ${
+                    chat.sender === "buyer"
+                      ? "bg-blue-600 text-white"
+                      : "bg-white text-foreground"
+                  }`}
+                >
+                  <p className="leading-relaxed">{chat.text}</p>
+                  <span
+                    className={`mt-1 block text-[10px] font-medium uppercase tracking-wide ${
+                      chat.sender === "buyer"
+                        ? "text-blue-100"
+                        : "text-muted-foreground"
+                    }`}
+                  >
+                    {chat.timestamp}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="space-y-2 text-xs text-muted-foreground">
+            <p className="font-medium">
+              ข้อแนะนำ: ปรึกษารายละเอียดสัญญาและการโอนกับผู้เชี่ยวชาญก่อนตัดสินใจ
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter className="sm:flex sm:flex-row sm:items-center sm:space-x-3">
+          <div className="flex w-full items-center gap-2">
+            <Input
+              value={message}
+              placeholder="พิมพ์ข้อความถึงผู้ขาย..."
+              onChange={(event) => setMessage(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  handleSendMessage();
+                }
+              }}
+            />
+            <Button onClick={handleSendMessage} type="button">
+              ส่งข้อความ
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/user-chat-dialog.tsx
+++ b/components/user-chat-dialog.tsx
@@ -1,18 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 
 interface UserChatDialogProps {
   open: boolean;
@@ -87,55 +81,104 @@ export function UserChatDialog({
     setMessage("");
   };
 
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onOpenChange(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onOpenChange]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader className="space-y-3">
-          <DialogTitle>แชทกับ {participantName}</DialogTitle>
-          <DialogDescription>
-            พูดคุยรายละเอียดเกี่ยวกับการซื้อบ้านแบบตัวต่อตัวกับผู้ขายรายนี้
-          </DialogDescription>
-          <div className="flex items-center gap-3 rounded-lg bg-muted/50 p-3">
-            <Avatar className="h-12 w-12">
+    <>
+      <div
+        role="presentation"
+        aria-hidden="true"
+        onClick={handleClose}
+        className={cn(
+          "fixed inset-0 z-30 bg-background/80 backdrop-blur-sm transition-opacity duration-300 lg:hidden",
+          open ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
+        )}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="user-chat-panel-title"
+        className={cn(
+          "fixed inset-y-0 right-0 z-40 flex w-full max-w-md flex-col border-l bg-background shadow-xl transition-transform duration-300 ease-in-out",
+          open ? "translate-x-0" : "translate-x-full",
+        )}
+      >
+        <header className="flex items-center justify-between border-b p-4">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-10 w-10">
               <AvatarImage src={participantAvatar ?? ""} alt={participantName} />
               <AvatarFallback className="font-semibold">
                 {participantInitials}
               </AvatarFallback>
             </Avatar>
-            <div>
-              <p className="text-sm font-semibold text-foreground">
-                {participantName}
+            <div className="space-y-1">
+              <p
+                id="user-chat-panel-title"
+                className="text-sm font-semibold text-foreground"
+              >
+                แชทกับ {participantName}
               </p>
               <p className="text-xs text-muted-foreground">
-                ตอบกลับโดยเฉลี่ยภายใน 30 นาที
+                พูดคุยรายละเอียดเกี่ยวกับการซื้อบ้านแบบตัวต่อตัวกับผู้ขายรายนี้
               </p>
             </div>
           </div>
-        </DialogHeader>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleClose}
+            aria-label="ปิดหน้าต่างแชท"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </header>
 
-        <div className="flex h-72 flex-col gap-4 rounded-lg border bg-muted/30 p-4">
+        <div className="flex flex-1 flex-col gap-4 p-4">
           <div className="flex-1 space-y-3 overflow-y-auto pr-1 text-sm">
             {messages.map((chat) => (
               <div
                 key={chat.id}
-                className={`flex ${
-                  chat.sender === "buyer" ? "justify-end" : "justify-start"
-                }`}
+                className={cn(
+                  "flex",
+                  chat.sender === "buyer" ? "justify-end" : "justify-start",
+                )}
               >
                 <div
-                  className={`max-w-[80%] rounded-2xl px-4 py-2 shadow-sm ${
+                  className={cn(
+                    "max-w-[80%] rounded-2xl px-4 py-2 shadow-sm",
                     chat.sender === "buyer"
                       ? "bg-blue-600 text-white"
-                      : "bg-white text-foreground"
-                  }`}
+                      : "bg-white text-foreground",
+                  )}
                 >
                   <p className="leading-relaxed">{chat.text}</p>
                   <span
-                    className={`mt-1 block text-[10px] font-medium uppercase tracking-wide ${
+                    className={cn(
+                      "mt-1 block text-[10px] font-medium uppercase tracking-wide",
                       chat.sender === "buyer"
                         ? "text-blue-100"
-                        : "text-muted-foreground"
-                    }`}
+                        : "text-muted-foreground",
+                    )}
                   >
                     {chat.timestamp}
                   </span>
@@ -143,15 +186,15 @@ export function UserChatDialog({
               </div>
             ))}
           </div>
-          <div className="space-y-2 text-xs text-muted-foreground">
+          <div className="space-y-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
             <p className="font-medium">
               ข้อแนะนำ: ปรึกษารายละเอียดสัญญาและการโอนกับผู้เชี่ยวชาญก่อนตัดสินใจ
             </p>
           </div>
         </div>
 
-        <DialogFooter className="sm:flex sm:flex-row sm:items-center sm:space-x-3">
-          <div className="flex w-full items-center gap-2">
+        <footer className="border-t bg-muted/10 p-4">
+          <div className="flex items-center gap-2">
             <Input
               value={message}
               placeholder="พิมพ์ข้อความถึงผู้ขาย..."
@@ -167,8 +210,8 @@ export function UserChatDialog({
               ส่งข้อความ
             </Button>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </footer>
+      </aside>
+    </>
   );
 }

--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -5,7 +5,6 @@ import { useMemo, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 
 import ChatWidget from "@/components/chat-widget";
-import { UserChatDialog } from "@/components/user-chat-dialog";
 import { UserPropertyCard } from "@/components/user-property-card";
 import { UserPropertyModal } from "@/components/user-property-modal";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -34,7 +33,7 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
   const [selectedProperty, setSelectedProperty] = useState<UserProperty | null>(
     null,
   );
-  const { isOpen: chatPanelOpen, setOpen: setChatPanelOpen } = useChatPanel();
+  const { openWith } = useChatPanel();
 
   const profileInitials = useMemo(() => {
     const name = profile?.name || "ผู้ขาย";
@@ -122,7 +121,14 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
               </div>
 
               <div className="flex w-full flex-col gap-2 sm:w-auto">
-                <Button onClick={() => setChatPanelOpen(true)}>
+                <Button
+                  onClick={() =>
+                    openWith({
+                      name: profile?.name ?? "ผู้ขาย",
+                      avatarUrl: profile?.photoURL ?? "",
+                    })
+                  }
+                >
                   เริ่มแชท 1 ต่อ 1
                 </Button>
                 {profile?.email && (
@@ -186,13 +192,6 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
         open={Boolean(selectedProperty)}
         property={selectedProperty}
         onOpenChange={handleModalChange}
-      />
-
-      <UserChatDialog
-        open={chatPanelOpen}
-        onOpenChange={setChatPanelOpen}
-        participantName={profile?.name ?? "ผู้ขาย"}
-        participantAvatar={profile?.photoURL ?? ""}
       />
 
       <ChatWidget />

--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -11,10 +11,10 @@ import { UserPropertyModal } from "@/components/user-property-modal";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { useChatPanel } from "@/contexts/chat-panel-context";
 import { useUserProfile } from "@/hooks/use-user-profile";
 import { useUserProperties } from "@/hooks/use-user-properties";
 import type { UserProperty } from "@/types/user-property";
-import { cn } from "@/lib/utils";
 
 interface UserProfilePageProps {
   uid: string;
@@ -34,7 +34,7 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
   const [selectedProperty, setSelectedProperty] = useState<UserProperty | null>(
     null,
   );
-  const [chatOpen, setChatOpen] = useState(false);
+  const { isOpen: chatPanelOpen, setOpen: setChatPanelOpen } = useChatPanel();
 
   const profileInitials = useMemo(() => {
     const name = profile?.name || "ผู้ขาย";
@@ -60,12 +60,7 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div
-        className={cn(
-          "mx-auto w-full max-w-6xl px-4 py-10 transition-all duration-300",
-          chatOpen ? "lg:pr-[28rem]" : "",
-        )}
-      >
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 transition-all duration-300">
         <div className="flex flex-col gap-8">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-3">
@@ -127,7 +122,7 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
               </div>
 
               <div className="flex w-full flex-col gap-2 sm:w-auto">
-                <Button onClick={() => setChatOpen(true)}>
+                <Button onClick={() => setChatPanelOpen(true)}>
                   เริ่มแชท 1 ต่อ 1
                 </Button>
                 {profile?.email && (
@@ -194,8 +189,8 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
       />
 
       <UserChatDialog
-        open={chatOpen}
-        onOpenChange={setChatOpen}
+        open={chatPanelOpen}
+        onOpenChange={setChatPanelOpen}
         participantName={profile?.name ?? "ผู้ขาย"}
         participantAvatar={profile?.photoURL ?? ""}
       />

--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
 import ChatWidget from "@/components/chat-widget";
@@ -10,7 +11,6 @@ import { UserPropertyModal } from "@/components/user-property-modal";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { useChatPanel } from "@/contexts/chat-panel-context";
 import { useUserProfile } from "@/hooks/use-user-profile";
 import { useUserProperties } from "@/hooks/use-user-properties";
 import type { UserProperty } from "@/types/user-property";
@@ -33,7 +33,7 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
   const [selectedProperty, setSelectedProperty] = useState<UserProperty | null>(
     null,
   );
-  const { openWith } = useChatPanel();
+  const router = useRouter();
 
   const profileInitials = useMemo(() => {
     const name = profile?.name || "ผู้ขาย";
@@ -122,12 +122,14 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
 
               <div className="flex w-full flex-col gap-2 sm:w-auto">
                 <Button
-                  onClick={() =>
-                    openWith({
-                      name: profile?.name ?? "ผู้ขาย",
-                      avatarUrl: profile?.photoURL ?? "",
-                    })
-                  }
+                  onClick={() => {
+                    const sellerName = profile?.name ?? "ผู้ขาย DreamHome";
+                    const params = new URLSearchParams({ name: sellerName });
+                    if (profile?.photoURL) {
+                      params.set("avatar", profile.photoURL);
+                    }
+                    router.push(`/chat/${uid}?${params.toString()}`);
+                  }}
                 >
                   เริ่มแชท 1 ต่อ 1
                 </Button>

--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 
 import ChatWidget from "@/components/chat-widget";
+import { UserChatDialog } from "@/components/user-chat-dialog";
 import { UserPropertyCard } from "@/components/user-property-card";
 import { UserPropertyModal } from "@/components/user-property-modal";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -32,6 +33,7 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
   const [selectedProperty, setSelectedProperty] = useState<UserProperty | null>(
     null,
   );
+  const [chatOpen, setChatOpen] = useState(false);
 
   const profileInitials = useMemo(() => {
     const name = profile?.name || "ผู้ขาย";
@@ -118,6 +120,9 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
             </div>
 
             <div className="flex w-full flex-col gap-2 sm:w-auto">
+              <Button onClick={() => setChatOpen(true)}>
+                เริ่มแชท 1 ต่อ 1
+              </Button>
               {profile?.email && (
                 <Button asChild variant="outline">
                   <a href={`mailto:${profile.email}`}>ติดต่อผู้ขายผ่านอีเมล</a>
@@ -178,6 +183,13 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
         open={Boolean(selectedProperty)}
         property={selectedProperty}
         onOpenChange={handleModalChange}
+      />
+
+      <UserChatDialog
+        open={chatOpen}
+        onOpenChange={setChatOpen}
+        participantName={profile?.name ?? "ผู้ขาย"}
+        participantAvatar={profile?.photoURL ?? ""}
       />
 
       <ChatWidget />

--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { useUserProfile } from "@/hooks/use-user-profile";
 import { useUserProperties } from "@/hooks/use-user-properties";
 import type { UserProperty } from "@/types/user-property";
+import { cn } from "@/lib/utils";
 
 interface UserProfilePageProps {
   uid: string;
@@ -59,124 +60,131 @@ export function UserProfilePage({ uid }: UserProfilePageProps) {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <Link
-              href="/buy"
-              className="inline-flex items-center text-sm text-blue-600 hover:text-blue-700"
-            >
-              <ArrowLeft className="mr-1 h-4 w-4" />
-              กลับไปหน้าซื้อ
-            </Link>
-            <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
-              ข้อมูลผู้ขาย
-            </h1>
+      <div
+        className={cn(
+          "mx-auto w-full max-w-6xl px-4 py-10 transition-all duration-300",
+          chatOpen ? "lg:pr-[28rem]" : "",
+        )}
+      >
+        <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <Link
+                href="/buy"
+                className="inline-flex items-center text-sm text-blue-600 hover:text-blue-700"
+              >
+                <ArrowLeft className="mr-1 h-4 w-4" />
+                กลับไปหน้าซื้อ
+              </Link>
+              <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+                ข้อมูลผู้ขาย
+              </h1>
+            </div>
           </div>
-        </div>
 
-        <Card>
-          <CardContent className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-1 flex-col gap-4 sm:flex-row sm:items-center">
-              <Avatar className="h-20 w-20 border">
-                <AvatarImage
-                  src={profile?.photoURL ?? ""}
-                  alt={profile?.name ?? "ผู้ขาย"}
-                />
-                <AvatarFallback className="text-lg">
-                  {profileInitials}
-                </AvatarFallback>
-              </Avatar>
-              <div className="space-y-2">
-                {profileLoading ? (
-                  <p className="text-sm text-muted-foreground">
-                    กำลังโหลดข้อมูลผู้ขาย...
-                  </p>
-                ) : profileError ? (
-                  <p className="text-sm text-red-600">{profileError}</p>
-                ) : profile ? (
-                  <>
-                    <p className="text-2xl font-semibold text-gray-900">
-                      {profile.name}
+          <Card>
+            <CardContent className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-1 flex-col gap-4 sm:flex-row sm:items-center">
+                <Avatar className="h-20 w-20 border">
+                  <AvatarImage
+                    src={profile?.photoURL ?? ""}
+                    alt={profile?.name ?? "ผู้ขาย"}
+                  />
+                  <AvatarFallback className="text-lg">
+                    {profileInitials}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="space-y-2">
+                  {profileLoading ? (
+                    <p className="text-sm text-muted-foreground">
+                      กำลังโหลดข้อมูลผู้ขาย...
                     </p>
-                    {profile.email && (
-                      <p className="text-sm text-gray-600">
-                        อีเมล: {profile.email}
+                  ) : profileError ? (
+                    <p className="text-sm text-red-600">{profileError}</p>
+                  ) : profile ? (
+                    <>
+                      <p className="text-2xl font-semibold text-gray-900">
+                        {profile.name}
                       </p>
-                    )}
-                    {profile.phoneNumber && (
-                      <p className="text-sm text-gray-600">
-                        เบอร์โทร: {profile.phoneNumber}
+                      {profile.email && (
+                        <p className="text-sm text-gray-600">
+                          อีเมล: {profile.email}
+                        </p>
+                      )}
+                      {profile.phoneNumber && (
+                        <p className="text-sm text-gray-600">
+                          เบอร์โทร: {profile.phoneNumber}
+                        </p>
+                      )}
+                      <p className="text-sm text-gray-500">
+                        ประกาศทั้งหมด {totalListings} รายการ
                       </p>
-                    )}
-                    <p className="text-sm text-gray-500">
-                      ประกาศทั้งหมด {totalListings} รายการ
-                    </p>
-                  </>
-                ) : (
-                  <p className="text-sm text-gray-600">ไม่พบข้อมูลผู้ขาย</p>
+                    </>
+                  ) : (
+                    <p className="text-sm text-gray-600">ไม่พบข้อมูลผู้ขาย</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex w-full flex-col gap-2 sm:w-auto">
+                <Button onClick={() => setChatOpen(true)}>
+                  เริ่มแชท 1 ต่อ 1
+                </Button>
+                {profile?.email && (
+                  <Button asChild variant="outline">
+                    <a href={`mailto:${profile.email}`}>ติดต่อผู้ขายผ่านอีเมล</a>
+                  </Button>
+                )}
+                {profile?.phoneNumber && (
+                  <Button asChild>
+                    <a href={`tel:${profile.phoneNumber}`}>โทรหาผู้ขาย</a>
+                  </Button>
                 )}
               </div>
+            </CardContent>
+          </Card>
+
+          <section className="space-y-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <h2 className="text-xl font-semibold text-gray-900">
+                ประกาศของผู้ขายรายนี้
+              </h2>
+              <p className="text-sm text-gray-500">แสดง {totalListings} รายการ</p>
             </div>
 
-            <div className="flex w-full flex-col gap-2 sm:w-auto">
-              <Button onClick={() => setChatOpen(true)}>
-                เริ่มแชท 1 ต่อ 1
-              </Button>
-              {profile?.email && (
-                <Button asChild variant="outline">
-                  <a href={`mailto:${profile.email}`}>ติดต่อผู้ขายผ่านอีเมล</a>
-                </Button>
-              )}
-              {profile?.phoneNumber && (
-                <Button asChild>
-                  <a href={`tel:${profile.phoneNumber}`}>โทรหาผู้ขาย</a>
-                </Button>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        <section className="space-y-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <h2 className="text-xl font-semibold text-gray-900">
-              ประกาศของผู้ขายรายนี้
-            </h2>
-            <p className="text-sm text-gray-500">แสดง {totalListings} รายการ</p>
-          </div>
-
-          {propertiesLoading ? (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 3 }).map((_, index) => (
-                <div
-                  key={index}
-                  className="flex h-full flex-col overflow-hidden rounded-2xl border bg-white p-4 shadow-sm animate-pulse"
-                >
-                  <div className="mb-4 h-40 w-full rounded-xl bg-gray-200" />
-                  <div className="space-y-3">
-                    <div className="h-4 w-3/4 rounded bg-gray-200" />
-                    <div className="h-4 w-1/2 rounded bg-gray-200" />
-                    <div className="h-4 w-full rounded bg-gray-200" />
+            {propertiesLoading ? (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="flex h-full flex-col overflow-hidden rounded-2xl border bg-white p-4 shadow-sm animate-pulse"
+                  >
+                    <div className="mb-4 h-40 w-full rounded-xl bg-gray-200" />
+                    <div className="space-y-3">
+                      <div className="h-4 w-3/4 rounded bg-gray-200" />
+                      <div className="h-4 w-1/2 rounded bg-gray-200" />
+                      <div className="h-4 w-full rounded bg-gray-200" />
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          ) : propertiesError ? (
-            <p className="text-sm text-red-600">{propertiesError}</p>
-          ) : properties.length === 0 ? (
-            <p className="text-gray-500">ผู้ขายรายนี้ยังไม่มีประกาศขาย</p>
-          ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {properties.map((property) => (
-                <UserPropertyCard
-                  key={property.id}
-                  property={property}
-                  onViewDetails={handleViewDetails}
-                />
-              ))}
-            </div>
-          )}
-        </section>
+                ))}
+              </div>
+            ) : propertiesError ? (
+              <p className="text-sm text-red-600">{propertiesError}</p>
+            ) : properties.length === 0 ? (
+              <p className="text-gray-500">ผู้ขายรายนี้ยังไม่มีประกาศขาย</p>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {properties.map((property) => (
+                  <UserPropertyCard
+                    key={property.id}
+                    property={property}
+                    onViewDetails={handleViewDetails}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
       </div>
 
       <UserPropertyModal

--- a/contexts/chat-panel-context.tsx
+++ b/contexts/chat-panel-context.tsx
@@ -4,18 +4,24 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
   type ReactNode,
 } from "react";
-import { usePathname } from "next/navigation";
+
+export interface ChatParticipant {
+  name: string;
+  avatarUrl?: string;
+}
 
 interface ChatPanelContextValue {
   isOpen: boolean;
+  participant: ChatParticipant | null;
   open: () => void;
+  openWith: (participant: ChatParticipant) => void;
   close: () => void;
   setOpen: (open: boolean) => void;
+  setParticipant: (participant: ChatParticipant | null) => void;
 }
 
 const ChatPanelContext = createContext<ChatPanelContextValue | undefined>(
@@ -28,24 +34,36 @@ export function ChatPanelProvider({
   children: ReactNode;
 }): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
-  const pathname = usePathname();
+  const [participant, setParticipant] = useState<ChatParticipant | null>(null);
 
   const open = useCallback(() => setIsOpen(true), []);
-  const close = useCallback(() => setIsOpen(false), []);
-  const setOpen = useCallback((next: boolean) => setIsOpen(next), []);
-
-  useEffect(() => {
+  const openWith = useCallback((nextParticipant: ChatParticipant) => {
+    setParticipant(nextParticipant);
+    setIsOpen(true);
+  }, []);
+  const close = useCallback(() => {
     setIsOpen(false);
-  }, [pathname]);
+    setParticipant(null);
+  }, []);
+  const setOpen = useCallback((next: boolean) => setIsOpen(next), []);
+  const handleSetParticipant = useCallback(
+    (nextParticipant: ChatParticipant | null) => {
+      setParticipant(nextParticipant);
+    },
+    [],
+  );
 
   const value = useMemo<ChatPanelContextValue>(
     () => ({
       isOpen,
       open,
+      openWith,
       close,
       setOpen,
+      participant,
+      setParticipant: handleSetParticipant,
     }),
-    [close, isOpen, open, setOpen],
+    [close, handleSetParticipant, isOpen, open, openWith, participant, setOpen],
   );
 
   return (

--- a/contexts/chat-panel-context.tsx
+++ b/contexts/chat-panel-context.tsx
@@ -83,5 +83,4 @@ export function useChatPanel(): ChatPanelContextValue {
   return context;
 }
 
-export const CHAT_PANEL_PADDING_CLASS = "lg:pr-[28rem]";
 export const CHAT_WIDGET_OFFSET_CLASS = "lg:right-[calc(28rem+1.5rem)]";

--- a/contexts/chat-panel-context.tsx
+++ b/contexts/chat-panel-context.tsx
@@ -83,4 +83,5 @@ export function useChatPanel(): ChatPanelContextValue {
   return context;
 }
 
-export const CHAT_WIDGET_OFFSET_CLASS = "lg:right-[calc(28rem+1.5rem)]";
+export const CHAT_WIDGET_OFFSET_CLASS =
+  "lg:right-[calc(var(--chat-panel-width,28rem)+var(--chat-panel-gutter,1.5rem))]";

--- a/contexts/chat-panel-context.tsx
+++ b/contexts/chat-panel-context.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
+
+interface ChatPanelContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  setOpen: (open: boolean) => void;
+}
+
+const ChatPanelContext = createContext<ChatPanelContextValue | undefined>(
+  undefined,
+);
+
+export function ChatPanelProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const setOpen = useCallback((next: boolean) => setIsOpen(next), []);
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
+  const value = useMemo<ChatPanelContextValue>(
+    () => ({
+      isOpen,
+      open,
+      close,
+      setOpen,
+    }),
+    [close, isOpen, open, setOpen],
+  );
+
+  return (
+    <ChatPanelContext.Provider value={value}>
+      {children}
+    </ChatPanelContext.Provider>
+  );
+}
+
+export function useChatPanel(): ChatPanelContextValue {
+  const context = useContext(ChatPanelContext);
+
+  if (!context) {
+    throw new Error("useChatPanel must be used within a ChatPanelProvider");
+  }
+
+  return context;
+}
+
+export const CHAT_PANEL_PADDING_CLASS = "lg:pr-[28rem]";
+export const CHAT_WIDGET_OFFSET_CLASS = "lg:right-[calc(28rem+1.5rem)]";

--- a/lib/mock-chats.ts
+++ b/lib/mock-chats.ts
@@ -1,0 +1,269 @@
+export interface ChatMessage {
+  id: string
+  author: "buyer" | "seller"
+  text: string
+  time: string
+  isHighlighted?: boolean
+}
+
+export interface ConversationSummary {
+  id: string
+  name: string
+  avatarUrl: string
+  preview: string
+  lastActive: string
+  unreadCount?: number
+  isOnline?: boolean
+  propertySummary?: string
+  badge?: string
+}
+
+export interface Conversation extends ConversationSummary {
+  messages: ChatMessage[]
+  buyerName: string
+  location?: string
+  askingPrice?: string
+  propertyId?: string
+}
+
+const mockConversations: Conversation[] = [
+  {
+    id: "siriporn-n-park-villa",
+    name: "ศิริพร ส.",
+    buyerName: "วิน เดอะ ซิตี้",
+    avatarUrl:
+      "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=facearea&facepad=2&w=120&h=120&q=80",
+    preview: "สวัสดีค่ะ สนใจนัดดูบ้านวันเสาร์นี้นะคะ",
+    lastActive: "8 ชม.",
+    unreadCount: 2,
+    isOnline: true,
+    propertySummary: "บ้านเดี่ยว เดอะ ซิตี้ บางนา",
+    badge: "ใหม่",
+    askingPrice: "฿5.2M",
+    location: "บางนา, กรุงเทพฯ",
+    propertyId: "dh-001",
+    messages: [
+      {
+        id: "1",
+        author: "seller",
+        text: "สวัสดีค่ะ บ้านหลังนี้ยังว่างอยู่ สนใจนัดดูไหมคะ",
+        time: "09:12",
+      },
+      {
+        id: "2",
+        author: "buyer",
+        text: "สวัสดีครับ อยากนัดดูวันเสาร์นี้ช่วงบ่ายได้ไหมครับ",
+        time: "09:15",
+      },
+      {
+        id: "3",
+        author: "seller",
+        text: "ได้ค่ะ บ่ายสองโมงสะดวกไหมคะ",
+        time: "09:17",
+      },
+      {
+        id: "4",
+        author: "buyer",
+        text: "สะดวกครับ แล้วเจอกันนะครับ",
+        time: "09:18",
+      },
+    ],
+  },
+  {
+    id: "sukanya-condo",
+    name: "สุกัญญา จ.",
+    buyerName: "ณัฐ บ้านและคอนโด",
+    avatarUrl:
+      "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=facearea&facepad=2&w=120&h=120&q=80",
+    preview: "คอนโดใกล้ BTS ยังว่างนะคะ มีโปรผ่อนดาวน์ 0%",
+    lastActive: "3 ชม.",
+    unreadCount: 1,
+    isOnline: false,
+    propertySummary: "คอนโดใจกลางเมือง",
+    askingPrice: "฿3.8M",
+    location: "อโศก, กรุงเทพฯ",
+    propertyId: "dh-124",
+    messages: [
+      {
+        id: "1",
+        author: "buyer",
+        text: "อยากทราบว่าห้องนี้เลี้ยงสัตว์ได้ไหมครับ",
+        time: "11:02",
+      },
+      {
+        id: "2",
+        author: "seller",
+        text: "เลี้ยงได้ค่ะ ถ้าเป็นสัตว์ขนาดเล็กไม่เกิน 10 กิโล",
+        time: "11:05",
+      },
+      {
+        id: "3",
+        author: "buyer",
+        text: "ขอบคุณครับ แล้วค่าส่วนกลางเท่าไรครับ",
+        time: "11:06",
+      },
+    ],
+  },
+  {
+    id: "onnapha-townhome",
+    name: "Onnapha",
+    buyerName: "100Kanajo",
+    avatarUrl:
+      "https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=facearea&facepad=2&w=120&h=120&q=80",
+    preview: "มีโปรโมชั่นโอนภายในเดือนนี้ลดอีก 50,000 บาท",
+    lastActive: "14 ชม.",
+    propertySummary: "ทาวน์โฮม 3 ชั้น",
+    askingPrice: "฿4.5M",
+    location: "วัชรพล, กรุงเทพฯ",
+    messages: [
+      {
+        id: "1",
+        author: "seller",
+        text: "มีโครงการ cashback 50,000 บาทถึงสิ้นเดือนนะคะ",
+        time: "16:40",
+      },
+      {
+        id: "2",
+        author: "buyer",
+        text: "ขอบคุณค่ะ ขอรูปห้องนอนเพิ่มอีกได้ไหมคะ",
+        time: "16:43",
+      },
+    ],
+  },
+  {
+    id: "family-rent-house",
+    name: "ธเนศกร family",
+    buyerName: "บ้านใกล้ BTS",
+    avatarUrl:
+      "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=facearea&facepad=2&w=120&h=120&q=80",
+    preview: "พรุ่งนี้ 10 โมงสะดวกให้เข้าไปดูบ้านไหมครับ",
+    lastActive: "1 ชม.",
+    unreadCount: 4,
+    isOnline: true,
+    propertySummary: "บ้านเดี่ยวให้เช่า",
+    messages: [
+      {
+        id: "1",
+        author: "buyer",
+        text: "มีที่จอดรถได้กี่คันครับ",
+        time: "08:20",
+      },
+      {
+        id: "2",
+        author: "seller",
+        text: "จอดได้สองคันครับ หน้าบ้านหนึ่ง ในบ้านหนึ่ง",
+        time: "08:24",
+      },
+      {
+        id: "3",
+        author: "buyer",
+        text: "โอเคครับ ขอเข้าไปดูบ้านพรุ่งนี้ช่วงสายๆ",
+        time: "08:25",
+      },
+    ],
+  },
+  {
+    id: "suwimon-apartment",
+    name: "สุวิมล ท.",
+    buyerName: "All Gen",
+    avatarUrl:
+      "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=facearea&facepad=2&w=120&h=120&q=80",
+    preview: "ยังสนใจห้องสตูดิโออยู่ไหมคะ เหลืออยู่ 2 ห้อง",
+    lastActive: "เมื่อคืน",
+    propertySummary: "อพาร์ตเมนต์หรู",
+    messages: [
+      {
+        id: "1",
+        author: "seller",
+        text: "ยังสนใจห้องสตูดิโออยู่ไหมคะ เหลืออยู่ 2 ห้อง",
+        time: "22:18",
+      },
+    ],
+  },
+  {
+    id: "luxury-pool-villa",
+    name: "วิวรรธนะ ก.",
+    buyerName: "Luxury Finder",
+    avatarUrl:
+      "https://images.unsplash.com/photo-1521579971123-1192931a1452?auto=format&fit=facearea&facepad=2&w=120&h=120&q=80",
+    preview: "ขอบคุณที่สนใจพูลวิลล่าสุดหรูนะครับ",
+    lastActive: "2 วัน",
+    propertySummary: "พูลวิลล่าพร้อมสระส่วนตัว",
+    messages: [
+      {
+        id: "1",
+        author: "buyer",
+        text: "พูลวิลล่าหลังนี้มีบริการแม่บ้านไหมครับ",
+        time: "15:22",
+      },
+      {
+        id: "2",
+        author: "seller",
+        text: "มีครับ สัปดาห์ละ 2 ครั้ง",
+        time: "15:30",
+      },
+    ],
+  },
+]
+
+export function getConversationSummaries(): ConversationSummary[] {
+  return mockConversations.map(({
+    id,
+    name,
+    avatarUrl,
+    preview,
+    lastActive,
+    unreadCount,
+    isOnline,
+    propertySummary,
+    badge,
+  }) => ({
+    id,
+    name,
+    avatarUrl,
+    preview,
+    lastActive,
+    unreadCount,
+    isOnline,
+    propertySummary,
+    badge,
+  }))
+}
+
+export function findConversationById(id: string): Conversation | undefined {
+  return mockConversations.find((conversation) => conversation.id === id)
+}
+
+export function createPlaceholderConversation({
+  id,
+  name,
+  avatarUrl,
+}: {
+  id: string
+  name: string
+  avatarUrl?: string
+}): Conversation {
+  return {
+    id,
+    name,
+    avatarUrl:
+      avatarUrl ||
+      "https://images.unsplash.com/photo-1520880867055-1e30d1cb001c?auto=format&fit=facearea&facepad=2&w=120&h=120&q=80",
+    preview: "เริ่มต้นสนทนาเพื่อสอบถามรายละเอียดบ้าน",
+    lastActive: "ตอนนี้",
+    buyerName: "คุณ",
+    messages: [
+      {
+        id: "intro",
+        author: "seller",
+        text: "สวัสดีค่ะ สนใจรายละเอียดเพิ่มเติมเกี่ยวกับบ้านหลังนี้ไหมคะ",
+        time: new Date().toLocaleTimeString("th-TH", {
+          hour: "2-digit",
+          minute: "2-digit",
+        }),
+      },
+    ],
+  }
+}
+
+export type { Conversation as MockConversation }


### PR DESCRIPTION
## Summary
- soften the global dialog overlay to use a translucent dark scrim with light blur so the underlying page remains visible while chatting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d96915c6e883219b7937fa36ac2903