### PR TITLE
Add chat attachment storage rules

### DIFF
--- a/docs/firebase-rules.md
+++ b/docs/firebase-rules.md
@@ -61,10 +61,21 @@ service firebase.storage {
       return request.auth != null;
     }
 
+    function isChatParticipant(chatId) {
+      let chat = get(/databases/(default)/documents/chats/$(chatId));
+      return isSignedIn() &&
+        chat.data.participants is list &&
+        chat.data.participants.hasAny([request.auth.uid]);
+    }
+
     match /propertyImages/{propertyId}/{allPaths=**} {
       allow read: if true;
       allow write: if isSignedIn();
       allow delete: if isSignedIn();
+    }
+
+    match /chat-attachments/{chatId}/{allPaths=**} {
+      allow read, write, delete: if isChatParticipant(chatId);
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,25 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isChatParticipant(chatId) {
+      let chat = get(/databases/(default)/documents/chats/$(chatId));
+      return isSignedIn() &&
+        chat.data.participants is list &&
+        chat.data.participants.hasAny([request.auth.uid]);
+    }
+
+    match /propertyImages/{propertyId}/{allPaths=**} {
+      allow read: if true;
+      allow write: if isSignedIn();
+      allow delete: if isSignedIn();
+    }
+
+    match /chat-attachments/{chatId}/{allPaths=**} {
+      allow read, write, delete: if isChatParticipant(chatId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an `isChatParticipant` helper to the storage rules to validate chat membership
- restrict chat attachment read/write/delete access to chat participants while leaving property image rules unchanged
- document the new chat attachment rule alongside the existing property image guidance

## Testing
- not run (Firebase deployment requires external credentials)


------
https://chatgpt.com/codex/tasks/task_e_68dc0cad2d008321afc91ce8f832f6cd