### PR TITLE
Make chat header name link to user profile

### DIFF
--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
   ArrowLeft,
@@ -1794,7 +1795,17 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
                           </AvatarFallback>
                         </Avatar>
                         <div className="flex flex-col">
-                          <span className="text-sm font-semibold text-gray-900">{getDisplayName(activeProfile)}</span>
+                          <Link
+                            href={activeParticipantId ? `/users/${activeParticipantId}` : "#"}
+                            className="text-sm font-semibold text-gray-900 transition hover:text-blue-600"
+                            onClick={(event) => {
+                              if (!activeParticipantId) {
+                                event.preventDefault()
+                              }
+                            }}
+                          >
+                            {getDisplayName(activeProfile)}
+                          </Link>
                           <span className="text-xs text-gray-500">พูดคุยเกี่ยวกับการซื้อบ้าน</span>
                         </div>
                       </div>

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1,5 +1,14 @@
 "use client"
-import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  ChangeEvent,
+  FormEvent,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import {
@@ -1372,6 +1381,29 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
     setIsGalleryOpen((prev) => !prev)
   }
 
+  const handleActiveProfileClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      if (!activeParticipantId) {
+        event.preventDefault()
+        return
+      }
+
+      if (
+        event.defaultPrevented ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey ||
+        event.button !== 0
+      ) {
+        return
+      }
+
+      onClose()
+    },
+    [activeParticipantId, onClose],
+  )
+
   const handleAttachmentClick = (attachment: ChatMessageAttachment) => {
     setSelectedAttachment(attachment)
     setIsMediaViewerOpen(true)
@@ -1798,11 +1830,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
                           <Link
                             href={activeParticipantId ? `/users/${activeParticipantId}` : "#"}
                             className="text-sm font-semibold text-gray-900 transition hover:text-blue-600"
-                            onClick={(event) => {
-                              if (!activeParticipantId) {
-                                event.preventDefault()
-                              }
-                            }}
+                            onClick={handleActiveProfileClick}
                           >
                             {getDisplayName(activeProfile)}
                           </Link>


### PR DESCRIPTION
## Summary
- wrap the active chat header name with a link to the participant's profile so it can be clicked

## Testing
- not run (ESLint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68ddc19b5b988321a1a57927d6d04a8e