### PR TITLE
Add chat presence indicators and update user status tracking

### DIFF
--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -14,6 +14,7 @@ import { useUserProfile } from "@/hooks/use-user-profile";
 import { useUserProperties } from "@/hooks/use-user-properties";
 import type { UserProperty } from "@/types/user-property";
 import type { PropertyPreviewOpenEventDetail } from "@/types/chat";
+import { getPresenceLabel, isPresenceOnline } from "@/lib/presence";
 
 interface UserProfilePageProps {
   uid: string;
@@ -87,6 +88,15 @@ export function UserProfilePage({ uid, initialPropertyId }: UserProfilePageProps
 
   const totalListings = properties.length;
 
+  const profilePresenceLabel = useMemo(
+    () => getPresenceLabel(profile?.status),
+    [profile?.status],
+  );
+  const isProfileOnline = useMemo(
+    () => isPresenceOnline(profile?.status),
+    [profile?.status],
+  );
+
   const handleViewDetails = (property: UserProperty) => {
     setSelectedProperty(property);
   };
@@ -152,6 +162,15 @@ export function UserProfilePage({ uid, initialPropertyId }: UserProfilePageProps
                     <p className="text-2xl font-semibold text-gray-900">
                       {profile.name}
                     </p>
+                    <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <span
+                        className={`h-2.5 w-2.5 rounded-full ${
+                          isProfileOnline ? "bg-emerald-500" : "bg-gray-300"
+                        }`}
+                        aria-hidden="true"
+                      />
+                      <span>{profilePresenceLabel}</span>
+                    </div>
                     {profile.email && (
                       <p className="text-sm text-gray-600">
                         อีเมล: {profile.email}

--- a/components/user-profile-page.tsx
+++ b/components/user-profile-page.tsx
@@ -12,9 +12,9 @@ import { Card, CardContent } from "@/components/ui/card";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useUserProfile } from "@/hooks/use-user-profile";
 import { useUserProperties } from "@/hooks/use-user-properties";
+import { usePresenceStatus } from "@/hooks/use-presence-status";
 import type { UserProperty } from "@/types/user-property";
 import type { PropertyPreviewOpenEventDetail } from "@/types/chat";
-import { getPresenceLabel, isPresenceOnline } from "@/lib/presence";
 
 interface UserProfilePageProps {
   uid: string;
@@ -88,14 +88,8 @@ export function UserProfilePage({ uid, initialPropertyId }: UserProfilePageProps
 
   const totalListings = properties.length;
 
-  const profilePresenceLabel = useMemo(
-    () => getPresenceLabel(profile?.status),
-    [profile?.status],
-  );
-  const isProfileOnline = useMemo(
-    () => isPresenceOnline(profile?.status),
-    [profile?.status],
-  );
+  const { label: profilePresenceLabel, isOnline: isProfileOnline } =
+    usePresenceStatus(profile?.status);
 
   const handleViewDetails = (property: UserProperty) => {
     setSelectedProperty(property);

--- a/components/user-property-modal.tsx
+++ b/components/user-property-modal.tsx
@@ -49,6 +49,7 @@ import {
   TRANSACTION_LABELS,
 } from "@/lib/property";
 import { cn } from "@/lib/utils";
+import { getPresenceLabel, isPresenceOnline } from "@/lib/presence";
 import type { UserProperty } from "@/types/user-property";
 import type { ChatOpenEventDetail, PropertyPreviewPayload } from "@/types/chat";
 
@@ -266,6 +267,14 @@ export function UserPropertyModal({
       .slice(0, 2)
       .toUpperCase();
   }, [property?.sellerName, sellerProfile?.name]);
+  const sellerPresenceLabel = useMemo(
+    () => getPresenceLabel(sellerProfile?.status),
+    [sellerProfile?.status],
+  );
+  const isSellerOnline = useMemo(
+    () => isPresenceOnline(sellerProfile?.status),
+    [sellerProfile?.status],
+  );
   const sellerListingsCount = sellerListings.length;
 
   const handleExpressInterest = useCallback(() => {
@@ -680,6 +689,16 @@ export function UserPropertyModal({
                     <p className="text-base font-semibold text-gray-900">
                       {sellerDisplayName}
                     </p>
+                    <div className="flex items-center gap-2 text-xs text-gray-500">
+                      <span
+                        className={cn(
+                          "h-2 w-2 rounded-full",
+                          isSellerOnline ? "bg-emerald-500" : "bg-gray-300",
+                        )}
+                        aria-hidden="true"
+                      />
+                      <span>{sellerPresenceLabel}</span>
+                    </div>
                     <p className="text-sm text-muted-foreground">
                       {sellerRoleLabel}
                     </p>

--- a/components/user-property-modal.tsx
+++ b/components/user-property-modal.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/dialog";
 import { useUserProfile } from "@/hooks/use-user-profile";
 import { useUserProperties } from "@/hooks/use-user-properties";
+import { usePresenceStatus } from "@/hooks/use-presence-status";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -49,7 +50,6 @@ import {
   TRANSACTION_LABELS,
 } from "@/lib/property";
 import { cn } from "@/lib/utils";
-import { getPresenceLabel, isPresenceOnline } from "@/lib/presence";
 import type { UserProperty } from "@/types/user-property";
 import type { ChatOpenEventDetail, PropertyPreviewPayload } from "@/types/chat";
 
@@ -267,14 +267,8 @@ export function UserPropertyModal({
       .slice(0, 2)
       .toUpperCase();
   }, [property?.sellerName, sellerProfile?.name]);
-  const sellerPresenceLabel = useMemo(
-    () => getPresenceLabel(sellerProfile?.status),
-    [sellerProfile?.status],
-  );
-  const isSellerOnline = useMemo(
-    () => isPresenceOnline(sellerProfile?.status),
-    [sellerProfile?.status],
-  );
+  const { label: sellerPresenceLabel, isOnline: isSellerOnline } =
+    usePresenceStatus(sellerProfile?.status);
   const sellerListingsCount = sellerListings.length;
 
   const handleExpressInterest = useCallback(() => {

--- a/hooks/use-presence-status.ts
+++ b/hooks/use-presence-status.ts
@@ -1,0 +1,69 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import type { PresenceLike } from "@/lib/presence"
+import { getPresenceLabel, isPresenceOnline } from "@/lib/presence"
+
+interface UsePresenceStatusOptions {
+  refreshIntervalMs?: number
+}
+
+interface PresenceStatusResult {
+  label: string
+  isOnline: boolean
+}
+
+const getLastActiveKey = (presence?: PresenceLike | null): number | string | null => {
+  if (!presence) return null
+
+  const value = presence.lastActiveAt
+  if (!value) return null
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.getTime()
+  }
+
+  if (typeof value === "string") {
+    return value
+  }
+
+  return null
+}
+
+export function usePresenceStatus(
+  presence?: PresenceLike | null,
+  options?: UsePresenceStatusOptions,
+): PresenceStatusResult {
+  const refreshIntervalMs = options?.refreshIntervalMs ?? 30_000
+  const lastActiveKey = getLastActiveKey(presence)
+  const stateKey = presence?.state ?? null
+
+  const computeLabel = useCallback(() => getPresenceLabel(presence), [presence, lastActiveKey, stateKey])
+  const [label, setLabel] = useState<string>(() => computeLabel())
+
+  useEffect(() => {
+    setLabel(computeLabel())
+  }, [computeLabel])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (!presence) return
+
+    if (isPresenceOnline(presence)) {
+      return
+    }
+
+    const interval = window.setInterval(() => {
+      setLabel(computeLabel())
+    }, refreshIntervalMs)
+
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [computeLabel, presence, refreshIntervalMs])
+
+  const isOnline = useMemo(() => isPresenceOnline(presence), [presence, lastActiveKey, stateKey])
+
+  return { label, isOnline }
+}

--- a/lib/presence.ts
+++ b/lib/presence.ts
@@ -27,8 +27,18 @@ export const isPresenceOnline = (
 ): boolean => {
   if (!presence) return false
 
-  const state = presence.state === "online" ? "online" : presence.state === "offline" ? "offline" : null
-  if (state !== "online") {
+  const state =
+    presence.state === "online"
+      ? "online"
+      : presence.state === "offline"
+        ? "offline"
+        : null
+
+  if (state === "online") {
+    return true
+  }
+
+  if (state === "offline") {
     return false
   }
 

--- a/lib/presence.ts
+++ b/lib/presence.ts
@@ -1,0 +1,79 @@
+export type PresenceState = "online" | "offline"
+
+export interface PresenceLike {
+  state?: PresenceState | string | null
+  lastActiveAt?: Date | string | null
+}
+
+export const ONLINE_THRESHOLD_MS = 2 * 60 * 1000
+
+const parseLastActiveAt = (value?: Date | string | null): Date | null => {
+  if (!value) return null
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value
+  }
+
+  if (typeof value === "string") {
+    const parsed = new Date(value)
+    return Number.isNaN(parsed.getTime()) ? null : parsed
+  }
+
+  return null
+}
+
+export const isPresenceOnline = (
+  presence?: PresenceLike | null,
+  options?: { thresholdMs?: number },
+): boolean => {
+  if (!presence) return false
+
+  const state = presence.state === "online" ? "online" : presence.state === "offline" ? "offline" : null
+  if (state !== "online") {
+    return false
+  }
+
+  const lastActiveAt = parseLastActiveAt(presence.lastActiveAt ?? null)
+  if (!lastActiveAt) {
+    return false
+  }
+
+  const threshold = options?.thresholdMs ?? ONLINE_THRESHOLD_MS
+  return Date.now() - lastActiveAt.getTime() <= threshold
+}
+
+export const formatPresenceLastActive = (
+  presence?: PresenceLike | null,
+): string => {
+  const lastActiveAt = parseLastActiveAt(presence?.lastActiveAt ?? null)
+  if (!lastActiveAt) return ""
+
+  const diffMs = Date.now() - lastActiveAt.getTime()
+
+  if (diffMs < 60_000) {
+    return "เมื่อสักครู่"
+  }
+
+  if (diffMs < 3_600_000) {
+    const minutes = Math.max(1, Math.floor(diffMs / 60_000))
+    return `${minutes} นาทีที่แล้ว`
+  }
+
+  if (diffMs < 86_400_000) {
+    const hours = Math.max(1, Math.floor(diffMs / 3_600_000))
+    return `${hours} ชั่วโมงที่แล้ว`
+  }
+
+  return new Intl.DateTimeFormat("th-TH", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(lastActiveAt)
+}
+
+export const getPresenceLabel = (presence?: PresenceLike | null): string => {
+  if (isPresenceOnline(presence)) {
+    return "ออนไลน์"
+  }
+
+  const lastActive = formatPresenceLastActive(presence)
+  return lastActive ? `ออฟไลน์ • ${lastActive}` : "ออฟไลน์"
+}

--- a/lib/user-profile-mapper.ts
+++ b/lib/user-profile-mapper.ts
@@ -1,6 +1,6 @@
 import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore";
 
-import type { UserProfile } from "@/types/user-profile";
+import type { UserProfile, UserStatus } from "@/types/user-profile";
 
 const toStringOrNull = (value: unknown): string | null => {
   if (typeof value === "string") return value;
@@ -32,6 +32,23 @@ const toIsoStringOrNull = (value: unknown): string | null => {
   return null;
 };
 
+const toUserStatus = (value: unknown): UserStatus | null => {
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  const state = record.state === "online" ? "online" : record.state === "offline" ? "offline" : undefined;
+  const lastActiveAt = toIsoStringOrNull(record.lastActiveAt);
+
+  if (!state && !lastActiveAt) {
+    return null;
+  }
+
+  return {
+    state: state ?? "offline",
+    lastActiveAt: lastActiveAt ?? null,
+  };
+};
+
 export const mapDocumentToUserProfile = (
   doc: QueryDocumentSnapshot<DocumentData>,
 ): UserProfile => {
@@ -46,5 +63,6 @@ export const mapDocumentToUserProfile = (
     phoneVerified: toBoolean(data.phoneVerified),
     createdAt: toIsoStringOrNull(data.createdAt),
     updatedAt: toIsoStringOrNull(data.updatedAt),
+    status: toUserStatus(data.status),
   };
 };

--- a/types/user-profile.ts
+++ b/types/user-profile.ts
@@ -1,3 +1,8 @@
+export interface UserStatus {
+  state: "online" | "offline";
+  lastActiveAt: string | null;
+}
+
 export interface UserProfile {
   uid: string;
   name: string;
@@ -7,4 +12,5 @@ export interface UserProfile {
   phoneVerified: boolean;
   createdAt: string | null;
   updatedAt: string | null;
+  status: UserStatus | null;
 }


### PR DESCRIPTION
## Summary
- track user presence in Firestore and keep it up to date while sessions are active
- surface online/offline indicators across the chat list, active conversation header, and seller profile surfaces
- add reusable presence helpers and extend user profile mapping to include status metadata

## Testing
- npm run lint *(blocked: command prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc9e1ce5c83219d5815f3e22f0060