### PR TITLE
Add listing share flows after creating a property

### DIFF
--- a/components/property-share-modal.tsx
+++ b/components/property-share-modal.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import type { UserProperty } from "@/types/user-property"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { PropertySharePanel } from "@/components/property-share-panel"
+
+interface PropertyShareModalProps {
+  open: boolean
+  property: UserProperty | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function PropertyShareModal({
+  open,
+  property,
+  onOpenChange,
+}: PropertyShareModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>แชร์ประกาศของคุณ</DialogTitle>
+          <DialogDescription>
+            ส่งประกาศนี้ไปยังโซเชียลมีเดียเพื่อให้ผู้ซื้อเห็นมากยิ่งขึ้น
+          </DialogDescription>
+        </DialogHeader>
+        {property && (
+          <PropertySharePanel
+            property={property}
+            hideHeading
+            className="border-0 bg-transparent p-0 shadow-none"
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/property-share-panel.tsx
+++ b/components/property-share-panel.tsx
@@ -1,0 +1,301 @@
+"use client"
+
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+import {
+  Copy,
+  Facebook,
+  Instagram,
+  Link as LinkIcon,
+  MessageCircle,
+  Share2,
+  Twitter,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { formatPropertyPrice } from "@/lib/property"
+import { useToast } from "@/hooks/use-toast"
+import type { UserProperty } from "@/types/user-property"
+
+interface PropertySharePanelProps {
+  property: ShareableProperty
+  className?: string
+  hideHeading?: boolean
+}
+
+type ShareableProperty = Pick<
+  UserProperty,
+  | "id"
+  | "title"
+  | "price"
+  | "transactionType"
+  | "userUid"
+  | "address"
+  | "city"
+  | "province"
+>
+
+interface ShareOption {
+  key: string
+  label: string
+  icon: ReactNode
+  onClick: () => void | Promise<void>
+  className?: string
+  variant?: "default" | "outline"
+}
+
+export function PropertySharePanel({
+  property,
+  className,
+  hideHeading = false,
+}: PropertySharePanelProps) {
+  const { toast } = useToast()
+  const envOrigin = useMemo(
+    () => (process.env.NEXT_PUBLIC_APP_URL ?? "").replace(/\/$/, ""),
+    [],
+  )
+  const [origin, setOrigin] = useState(envOrigin)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    setOrigin(window.location.origin)
+  }, [])
+
+  const listingUrl = useMemo(() => {
+    const base = origin.replace(/\/$/, "")
+    if (property.userUid) {
+      return base
+        ? `${base}/users/${property.userUid}?propertyId=${property.id}`
+        : `/users/${property.userUid}?propertyId=${property.id}`
+    }
+    return base
+      ? `${base}/buy?propertyId=${property.id}`
+      : `/buy?propertyId=${property.id}`
+  }, [origin, property.id, property.userUid])
+
+  const priceLabel = useMemo(
+    () => formatPropertyPrice(property.price, property.transactionType),
+    [property.price, property.transactionType],
+  )
+
+  const locationLine = useMemo(
+    () =>
+      [property.address, property.city, property.province]
+        .map((value) => value?.trim())
+        .filter(Boolean)
+        .join(", "),
+    [property.address, property.city, property.province],
+  )
+
+  const shareMessage = useMemo(() => {
+    const lines = [
+      "🎉 ชมประกาศอสังหาฯ ของฉัน!",
+      `${property.title} - ${priceLabel}`,
+    ]
+    if (locationLine) lines.push(locationLine)
+    lines.push(listingUrl)
+    return lines.join("\n")
+  }, [locationLine, listingUrl, priceLabel, property.title])
+
+  const encodedUrl = useMemo(() => encodeURIComponent(listingUrl), [listingUrl])
+  const encodedHeadline = useMemo(
+    () => encodeURIComponent(`${property.title} - ${priceLabel}`),
+    [priceLabel, property.title],
+  )
+  const encodedMessage = useMemo(
+    () => encodeURIComponent(shareMessage),
+    [shareMessage],
+  )
+
+  const copyText = useCallback(
+    async (text: string, successMessage: string) => {
+      try {
+        if (
+          typeof navigator !== "undefined" &&
+          navigator.clipboard &&
+          typeof navigator.clipboard.writeText === "function"
+        ) {
+          await navigator.clipboard.writeText(text)
+        } else if (typeof document !== "undefined") {
+          const textArea = document.createElement("textarea")
+          textArea.value = text
+          textArea.style.position = "fixed"
+          textArea.style.opacity = "0"
+          document.body.appendChild(textArea)
+          textArea.focus()
+          textArea.select()
+          document.execCommand("copy")
+          document.body.removeChild(textArea)
+        } else {
+          throw new Error("clipboard unavailable")
+        }
+
+        toast({
+          title: "คัดลอกสำเร็จ",
+          description: successMessage,
+        })
+      } catch (error) {
+        console.error("Failed to copy text", error)
+        toast({
+          title: "คัดลอกไม่สำเร็จ",
+          description: "โปรดลองอีกครั้ง",
+          variant: "destructive",
+        })
+      }
+    },
+    [toast],
+  )
+
+  const openShareWindow = useCallback((url: string) => {
+    if (typeof window === "undefined") return
+    window.open(url, "_blank", "noopener,noreferrer")
+  }, [])
+
+  const shareOptions: ShareOption[] = useMemo(
+    () => [
+      {
+        key: "facebook",
+        label: "Facebook",
+        icon: <Facebook className="h-4 w-4" />,
+        onClick: () =>
+          openShareWindow(
+            `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+          ),
+        className:
+          "bg-[#1877F2] text-white hover:bg-[#1459C3] focus-visible:ring-[#1877F2]",
+      },
+      {
+        key: "instagram",
+        label: "Instagram",
+        icon: <Instagram className="h-4 w-4" />,
+        onClick: async () => {
+          await copyText(
+            shareMessage,
+            "คัดลอกข้อความสำหรับ Instagram แล้ว",
+          )
+          openShareWindow("https://www.instagram.com/")
+        },
+        className:
+          "bg-gradient-to-r from-pink-500 via-rose-500 to-amber-400 text-white hover:from-pink-600 hover:via-rose-600 hover:to-amber-400 focus-visible:ring-pink-500",
+      },
+      {
+        key: "line",
+        label: "Line",
+        icon: <MessageCircle className="h-4 w-4" />,
+        onClick: () =>
+          openShareWindow(
+            `https://social-plugins.line.me/lineit/share?url=${encodedUrl}&text=${encodedHeadline}`,
+          ),
+        className:
+          "bg-[#06C755] text-white hover:bg-[#05b44b] focus-visible:ring-[#06C755]",
+      },
+      {
+        key: "whatsapp",
+        label: "WhatsApp",
+        icon: <MessageCircle className="h-4 w-4" />,
+        onClick: () =>
+          openShareWindow(
+            `https://api.whatsapp.com/send?text=${encodedMessage}`,
+          ),
+        className:
+          "bg-[#25D366] text-white hover:bg-[#1da955] focus-visible:ring-[#25D366]",
+      },
+      {
+        key: "twitter",
+        label: "Twitter / X",
+        icon: <Twitter className="h-4 w-4" />,
+        onClick: () =>
+          openShareWindow(
+            `https://twitter.com/intent/tweet?text=${encodedHeadline}&url=${encodedUrl}`,
+          ),
+        className: "bg-black text-white hover:bg-gray-900 focus-visible:ring-black",
+      },
+      {
+        key: "copy-link",
+        label: "คัดลอกลิงก์",
+        icon: <LinkIcon className="h-4 w-4" />,
+        onClick: () =>
+          copyText(listingUrl, "คัดลอกลิงก์ประกาศแล้ว"),
+        className: "bg-white text-gray-900 hover:bg-gray-100",
+        variant: "outline",
+      },
+    ],
+    [
+      copyText,
+      encodedHeadline,
+      encodedMessage,
+      encodedUrl,
+      listingUrl,
+      openShareWindow,
+      shareMessage,
+    ],
+  )
+
+  return (
+    <div
+      className={cn(
+        "space-y-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm",
+        className,
+      )}
+    >
+      {!hideHeading && (
+        <div className="space-y-1">
+          <h2 className="flex items-center gap-2 text-xl font-semibold text-gray-900">
+            <Share2 className="h-5 w-5 text-purple-600" />
+            แชร์ประกาศของคุณ
+          </h2>
+          <p className="text-sm text-gray-600">
+            ส่งลิงก์ประกาศไปยังโซเชียลมีเดียเพื่อเข้าถึงผู้ซื้อจำนวนมากขึ้น
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm font-medium text-gray-900">ข้อความอัตโนมัติ</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              copyText(shareMessage, "คัดลอกข้อความประกาศแล้ว")
+            }
+            className="gap-2"
+          >
+            <Copy className="h-4 w-4" />
+            คัดลอกข้อความ
+          </Button>
+        </div>
+        <div className="whitespace-pre-line rounded-xl border border-dashed border-purple-200 bg-purple-50/70 p-4 text-sm text-gray-700">
+          {shareMessage}
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
+        {shareOptions.map((option) => (
+          <Button
+            key={option.key}
+            type="button"
+            variant={option.variant ?? "default"}
+            onClick={() => {
+              void option.onClick()
+            }}
+            className={cn(
+              "flex items-center justify-center gap-2 py-3 text-sm font-semibold shadow-sm",
+              option.className,
+            )}
+          >
+            {option.icon}
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/sell-property-form.tsx
+++ b/components/sell-property-form.tsx
@@ -8,6 +8,7 @@ import {
   Bath,
   Bed,
   Car,
+  Ruler,
   LocateFixed,
   MapPin,
   PartyPopper,

--- a/components/sell-property-form.tsx
+++ b/components/sell-property-form.tsx
@@ -8,6 +8,7 @@ import {
   Bath,
   Bed,
   Car,
+  ArrowLeft,
   Ruler,
   LocateFixed,
   MapPin,
@@ -1375,6 +1376,10 @@ function SellPropertySuccess({
 
   useEffect(() => {
     setShareOpen(false)
+
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" })
+    }
   }, [property.id])
 
   const priceLabel = useMemo(
@@ -1450,9 +1455,22 @@ function SellPropertySuccess({
 
   return (
     <>
-      <div className={`${inter.className} min-h-screen bg-gradient-to-b from-gray-50 to-white`}> 
-        <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10">
-          <div className="rounded-3xl border border-emerald-200 bg-white px-6 py-8 text-center shadow-sm sm:px-10 sm:py-10">
+      <div className={`${inter.className} min-h-screen bg-gradient-to-b from-gray-50 to-white`}>
+        <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-10">
+          <div className="flex justify-start">
+            <Button
+              asChild
+              variant="ghost"
+              className="group gap-2 text-gray-600 hover:text-gray-900"
+            >
+              <Link href="/sell" className="flex items-center">
+                <ArrowLeft className="h-4 w-4 transition-transform duration-200 group-hover:-translate-x-1" />
+                กลับ
+              </Link>
+            </Button>
+          </div>
+
+          <div className="rounded-3xl border border-emerald-200 bg-white px-6 py-8 text-center shadow-sm animate-fade-in-down sm:px-10 sm:py-10">
             <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
               <PartyPopper className="h-8 w-8" />
             </div>
@@ -1464,7 +1482,7 @@ function SellPropertySuccess({
             </p>
           </div>
 
-          <div className="overflow-hidden rounded-3xl border bg-white shadow-sm">
+          <div className="overflow-hidden rounded-3xl border bg-white shadow-sm animate-fade-in-up">
             <div className="grid grid-cols-1 gap-0 md:grid-cols-[1.2fr_1fr]">
               <div className="relative h-60 w-full bg-gray-100 md:h-full">
                 {primaryImage ? (
@@ -1555,7 +1573,9 @@ function SellPropertySuccess({
             </div>
           </div>
 
-          <PropertySharePanel property={property} />
+          <div className="animate-fade-in-up">
+            <PropertySharePanel property={property} />
+          </div>
         </div>
       </div>
       <PropertyShareModal

--- a/components/user-property-modal.tsx
+++ b/components/user-property-modal.tsx
@@ -23,6 +23,7 @@ import {
   Phone,
   Mail,
   Ruler,
+  Share2,
   Square,
   Video,
 } from "lucide-react";
@@ -52,6 +53,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { UserProperty } from "@/types/user-property";
 import type { ChatOpenEventDetail, PropertyPreviewPayload } from "@/types/chat";
+import { PropertyShareModal } from "@/components/property-share-modal";
 
 interface UserPropertyModalProps {
   open: boolean;
@@ -72,6 +74,7 @@ export function UserPropertyModal({
   const { user } = useAuthContext();
   const { toast } = useToast();
   const [hasSentInterest, setHasSentInterest] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
 
   const userUid = property?.userUid?.trim() ? property.userUid : null;
   const sellerProfileHref = userUid ? `/users/${userUid}` : null;
@@ -89,6 +92,10 @@ export function UserPropertyModal({
   useEffect(() => {
     setActiveMediaIndex(0);
     setHasSentInterest(false);
+  }, [property?.id]);
+
+  useEffect(() => {
+    setShareOpen(false);
   }, [property?.id]);
 
   const mediaItems = useMemo(() => {
@@ -416,8 +423,9 @@ export function UserPropertyModal({
       : null;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-full max-w-[calc(100vw-2rem)] max-h-[calc(100vh-3rem)] overflow-y-auto overflow-x-hidden p-3 xs:p-4 sm:max-w-3xl sm:max-h-[90vh] sm:p-6 md:max-w-5xl lg:max-w-6xl lg:p-8 xl:max-w-7xl">
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="w-full max-w-[calc(100vw-2rem)] max-h-[calc(100vh-3rem)] overflow-y-auto overflow-x-hidden p-3 xs:p-4 sm:max-w-3xl sm:max-h-[90vh] sm:p-6 md:max-w-5xl lg:max-w-6xl lg:p-8 xl:max-w-7xl">
         <DialogHeader className="space-y-4">
           <div className="space-y-2">
             <DialogTitle className="text-xl font-bold text-gray-900 sm:text-2xl">
@@ -734,6 +742,18 @@ export function UserPropertyModal({
                   )}
                 </div>
 
+                {property?.id && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full justify-center gap-2"
+                    onClick={() => setShareOpen(true)}
+                  >
+                    <Share2 className="h-4 w-4" />
+                    แชร์ประกาศนี้
+                  </Button>
+                )}
+
                 {property.userUid && (
                   <Button
                     className="w-full justify-center bg-blue-600 text-white hover:bg-blue-700"
@@ -781,7 +801,13 @@ export function UserPropertyModal({
             <p className="text-sm text-muted-foreground">กำลังโหลดรายละเอียดล่าสุด...</p>
           </div>
         )}
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+      <PropertyShareModal
+        open={shareOpen && Boolean(property)}
+        property={property}
+        onOpenChange={setShareOpen}
+      />
+    </>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -70,10 +70,20 @@ const config: Config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "fade-in-down": {
+          from: { opacity: "0", transform: "translateY(-12px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        "fade-in-up": {
+          from: { opacity: "0", transform: "translateY(12px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "fade-in-down": "fade-in-down 0.45s ease-out both",
+        "fade-in-up": "fade-in-up 0.45s ease-out both",
       },
     },
   },


### PR DESCRIPTION
## Summary
- add reusable property sharing panel and modal with platform-specific actions
- show a dedicated post-creation success view with listing preview and share entry points
- surface a share button inside the property detail modal to open the sharing modal

## Testing
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dfed385f988321b2dc5eb125eaf070