### PR TITLE
Add handover scheduling and defect tracking workflow

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -172,7 +172,7 @@ export default function BlogPage() {
                 </div>
                 <CardContent className="p-4">
                   <div className="flex items-center gap-2 mb-3">
-                    <Badge variant="outline" size="sm">
+                    <Badge variant="outline">
                       {post.category}
                     </Badge>
                     <span className="text-xs text-gray-500">{post.readTime}</span>

--- a/app/buy/home-inspection/page.tsx
+++ b/app/buy/home-inspection/page.tsx
@@ -47,6 +47,7 @@ import type {
   HomeInspectionChecklistItem,
   HomeInspectionIssue,
   HomeInspectionNotification,
+  HomeInspectionNotificationCountDetail,
   HomeInspectionState,
 } from "@/types/home-inspection"
 import type { UserProperty } from "@/types/user-property"
@@ -205,6 +206,19 @@ export default function BuyerHomeInspectionPage() {
   const [notifications, setNotifications] = useState<HomeInspectionNotification[]>([])
   const [notificationsLoading, setNotificationsLoading] = useState(true)
   const [notificationsOpen, setNotificationsOpen] = useState(false)
+
+  useEffect(() => {
+    const handleOpenNotifications = () => setNotificationsOpen(true)
+
+    window.addEventListener("dreamhome:open-inspection-notifications", handleOpenNotifications)
+
+    return () => {
+      window.removeEventListener(
+        "dreamhome:open-inspection-notifications",
+        handleOpenNotifications,
+      )
+    }
+  }, [])
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -499,6 +513,35 @@ export default function BuyerHomeInspectionPage() {
     () => notifications.filter((notification) => !notification.read),
     [notifications],
   )
+  const unreadNotificationCount = unreadNotifications.length
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    window.dispatchEvent(
+      new CustomEvent<HomeInspectionNotificationCountDetail>(
+        "dreamhome:inspection-notification-count",
+        {
+          detail: { count: unreadNotificationCount },
+        },
+      ),
+    )
+  }, [unreadNotificationCount])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent<HomeInspectionNotificationCountDetail>(
+          "dreamhome:inspection-notification-count",
+          {
+            detail: { count: 0 },
+          },
+        ),
+      )
+    }
+  }, [])
 
   useEffect(() => {
     if (!notificationsOpen || !propertyId) return

--- a/app/buy/home-inspection/page.tsx
+++ b/app/buy/home-inspection/page.tsx
@@ -1505,7 +1505,7 @@ export default function BuyerHomeInspectionPage() {
       </Dialog>
 
       <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
-        <DialogContent className="w-[min(95vw,38rem)] max-w-2xl sm:max-w-xl">
+        <DialogContent className="w-[min(95vw,38rem)] max-h-[calc(100vh-4rem)] overflow-y-auto max-w-2xl sm:max-w-xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
               <AlertCircle className="h-5 w-5 text-purple-600" />

--- a/app/buy/home-inspection/page.tsx
+++ b/app/buy/home-inspection/page.tsx
@@ -1,0 +1,680 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { format, parseISO } from "date-fns";
+import {
+  AlertCircle,
+  Calendar as CalendarIcon,
+  CheckCircle2,
+  ClipboardCheck,
+  ClipboardList,
+  Clock,
+  Compass,
+  MessageCircle,
+  ShieldCheck,
+  Sparkles,
+  Wrench,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+
+interface BuyerChecklistItem {
+  id: string;
+  title: string;
+  description: string;
+  sellerStatus: "scheduled" | "fixing" | "done";
+  buyerStatus: "pending" | "accepted" | "follow-up";
+  lastUpdatedAt: string;
+}
+
+type BuyerIssueStatus = "pending" | "in-progress" | "resolved";
+
+interface BuyerIssue {
+  id: string;
+  title: string;
+  location: string;
+  description: string;
+  status: BuyerIssueStatus;
+  reportedAt: string;
+  sellerOwner: string;
+  expectedCompletion?: string;
+  resolvedAt?: string;
+}
+
+const sellerStatusMeta: Record<BuyerChecklistItem["sellerStatus"], { label: string; tone: string }> = {
+  scheduled: {
+    label: "พร้อมให้ตรวจ",
+    tone: "bg-blue-100 text-blue-700 border-blue-200",
+  },
+  fixing: {
+    label: "ผู้ขายกำลังแก้",
+    tone: "bg-amber-100 text-amber-700 border-amber-200",
+  },
+  done: {
+    label: "ผู้ขายยืนยันแล้ว",
+    tone: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  },
+};
+
+const buyerStatusMeta: Record<BuyerChecklistItem["buyerStatus"], { label: string; tone: string; description: string }> = {
+  pending: {
+    label: "รอตรวจ",
+    tone: "bg-slate-100 text-slate-700 border-slate-200",
+    description: "ยังไม่ได้ตรวจหรือบันทึกผล",
+  },
+  accepted: {
+    label: "ผ่าน",
+    tone: "bg-emerald-100 text-emerald-700 border-emerald-200",
+    description: "ยืนยันว่าเรียบร้อย",
+  },
+  "follow-up": {
+    label: "ขอตรวจซ้ำ",
+    tone: "bg-purple-100 text-purple-700 border-purple-200",
+    description: "ต้องการให้ผู้ขายปรับปรุงเพิ่ม",
+  },
+};
+
+const issueStatusMeta: Record<BuyerIssueStatus, { label: string; tone: string }> = {
+  pending: {
+    label: "รอตรวจสอบ",
+    tone: "bg-amber-100 text-amber-700 border-amber-200",
+  },
+  "in-progress": {
+    label: "ผู้ขายกำลังแก้",
+    tone: "bg-blue-100 text-blue-700 border-blue-200",
+  },
+  resolved: {
+    label: "ตรวจแล้วเรียบร้อย",
+    tone: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  },
+};
+
+const initialPlan = {
+  sellerDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  location: "โครงการ Dream Ville บางนา",
+  sellerContact: "คุณฟ้า (ตัวแทนผู้ขาย)",
+};
+
+const initialChecklist: BuyerChecklistItem[] = [
+  {
+    id: "structure",
+    title: "ตรวจโครงสร้างและผนัง",
+    description: "เช็คผิวผนัง รอยแตกร้าว และการปรับระดับพื้น",
+    sellerStatus: "scheduled",
+    buyerStatus: "pending",
+    lastUpdatedAt: new Date().toISOString(),
+  },
+  {
+    id: "plumbing",
+    title: "ระบบน้ำและสุขภัณฑ์",
+    description: "เปิดวาล์ว ทดสอบแรงดันน้ำ และดูการรั่วซึม",
+    sellerStatus: "fixing",
+    buyerStatus: "follow-up",
+    lastUpdatedAt: new Date().toISOString(),
+  },
+  {
+    id: "electrical",
+    title: "ระบบไฟฟ้าและสวิตช์",
+    description: "ตรวจปลั๊ก แสงสว่าง และเบรกเกอร์",
+    sellerStatus: "done",
+    buyerStatus: "accepted",
+    lastUpdatedAt: new Date().toISOString(),
+  },
+];
+
+const initialIssues: BuyerIssue[] = [
+  {
+    id: "kitchen-cabinet",
+    title: "บานตู้ครัวปิดไม่สนิท",
+    location: "ห้องครัว",
+    description: "ขอให้ผู้ขายปรับบานพับเพื่อให้ปิดสนิท",
+    status: "in-progress",
+    reportedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    sellerOwner: "ทีมช่างผู้ขาย",
+    expectedCompletion: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "bathroom-silicone",
+    title: "ยาแนวห้องน้ำหลุด",
+    location: "ห้องน้ำชั้นบน",
+    description: "ต้องการให้เก็บซิลิโคนรอบอ่างอาบน้ำใหม่",
+    status: "pending",
+    reportedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    sellerOwner: "Foreman คุณเอ็ม",
+  },
+];
+
+export default function BuyerHomeInspectionPage() {
+  const [activeTab, setActiveTab] = useState<string>("overview");
+  const [preferredDate, setPreferredDate] = useState<string>(() => initialPlan.sellerDate.slice(0, 10));
+  const [buyerNote, setBuyerNote] = useState<string>("");
+  const [checklistItems, setChecklistItems] = useState<BuyerChecklistItem[]>(initialChecklist);
+  const [issues, setIssues] = useState<BuyerIssue[]>(initialIssues);
+  const [newChecklistTitle, setNewChecklistTitle] = useState("");
+  const [newChecklistDescription, setNewChecklistDescription] = useState("");
+  const [reportDialogOpen, setReportDialogOpen] = useState(false);
+  const [reportTitle, setReportTitle] = useState("");
+  const [reportDescription, setReportDescription] = useState("");
+  const [reportLocation, setReportLocation] = useState("");
+  const [reportExpectedDate, setReportExpectedDate] = useState("");
+
+  const confirmedDateLabel = useMemo(() => {
+    try {
+      return format(parseISO(`${preferredDate}T09:00:00`), "d MMM yyyy");
+    } catch {
+      return preferredDate;
+    }
+  }, [preferredDate]);
+
+  const sellerDateLabel = useMemo(() => {
+    return format(parseISO(initialPlan.sellerDate), "d MMM yyyy");
+  }, []);
+
+  const displayDateLabel = confirmedDateLabel || sellerDateLabel;
+
+  const overviewStats = useMemo(() => {
+    const total = checklistItems.length;
+    const accepted = checklistItems.filter((item) => item.buyerStatus === "accepted").length;
+    const followUp = checklistItems.filter((item) => item.buyerStatus === "follow-up").length;
+    return {
+      total,
+      accepted,
+      followUp,
+      completion: total > 0 ? Math.round((accepted / total) * 100) : 0,
+    };
+  }, [checklistItems]);
+
+  const timelineEvents = useMemo(() => {
+    const buyerDateIso = preferredDate
+      ? new Date(`${preferredDate}T09:00:00`).toISOString()
+      : initialPlan.sellerDate;
+
+    const events: { id: string; title: string; description: string; date: string; tone: string }[] = [
+      {
+        id: "seller-proposed",
+        title: "ผู้ขายเสนอวันส่งมอบ",
+        description: format(parseISO(initialPlan.sellerDate), "EEEE d MMMM yyyy"),
+        date: initialPlan.sellerDate,
+        tone: "border-blue-200 bg-blue-50",
+      },
+      {
+        id: "buyer-confirm",
+        title: "ผู้ซื้อเลือกวันที่สะดวก",
+        description: confirmedDateLabel
+          ? `ตรวจเช้าตามที่สะดวก (${confirmedDateLabel})`
+          : "รอผู้ซื้อยืนยันเวลาที่สะดวก",
+        date: buyerDateIso,
+        tone: "border-emerald-200 bg-emerald-50",
+      },
+    ];
+
+    issues.forEach((issue) => {
+      events.push({
+        id: `${issue.id}-reported`,
+        title: `รายงานปัญหา: ${issue.title}`,
+        description: issue.location,
+        date: issue.reportedAt,
+        tone: "border-amber-200 bg-amber-50",
+      });
+
+      if (issue.expectedCompletion) {
+        events.push({
+          id: `${issue.id}-due`,
+          title: `กำหนดแก้ไขโดย ${issue.sellerOwner}`,
+          description: format(parseISO(issue.expectedCompletion), "d MMM yyyy"),
+          date: issue.expectedCompletion,
+          tone: "border-purple-200 bg-purple-50",
+        });
+      }
+
+      if (issue.resolvedAt) {
+        events.push({
+          id: `${issue.id}-resolved`,
+          title: `ปิดงาน: ${issue.title}`,
+          description: format(parseISO(issue.resolvedAt), "d MMM yyyy"),
+          date: issue.resolvedAt,
+          tone: "border-emerald-200 bg-emerald-50",
+        });
+      }
+    });
+
+    return events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }, [issues, preferredDate, confirmedDateLabel]);
+
+  const handleUpdateBuyerStatus = (id: string, status: BuyerChecklistItem["buyerStatus"]) => {
+    setChecklistItems((items) =>
+      items.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              buyerStatus: status,
+              lastUpdatedAt: new Date().toISOString(),
+            }
+          : item,
+      ),
+    );
+  };
+
+  const handleAddChecklistItem = () => {
+    if (!newChecklistTitle.trim()) return;
+
+    const newItem: BuyerChecklistItem = {
+      id: `custom-${Date.now()}`,
+      title: newChecklistTitle.trim(),
+      description: newChecklistDescription.trim() || "ระบุรายละเอียดสิ่งที่ต้องการตรวจ",
+      sellerStatus: "scheduled",
+      buyerStatus: "pending",
+      lastUpdatedAt: new Date().toISOString(),
+    };
+
+    setChecklistItems((items) => [newItem, ...items]);
+    setNewChecklistTitle("");
+    setNewChecklistDescription("");
+  };
+
+  const handleSubmitIssue = () => {
+    if (!reportTitle.trim() || !reportLocation.trim()) {
+      return;
+    }
+
+    const issue: BuyerIssue = {
+      id: `issue-${Date.now()}`,
+      title: reportTitle.trim(),
+      location: reportLocation.trim(),
+      description: reportDescription.trim() || "",
+      status: "pending",
+      reportedAt: new Date().toISOString(),
+      sellerOwner: "รอผู้ขายมอบหมาย",
+      expectedCompletion: reportExpectedDate ? `${reportExpectedDate}T09:00:00` : undefined,
+    };
+
+    setIssues((current) => [issue, ...current]);
+    setReportDialogOpen(false);
+    setReportTitle("");
+    setReportDescription("");
+    setReportLocation("");
+    setReportExpectedDate("");
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 py-10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
+        <div className="space-y-4 rounded-3xl bg-white p-6 shadow-sm sm:p-8">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="inline-flex items-center gap-2 rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+              <ClipboardList className="h-4 w-4" />
+              ขั้นตอนตรวจรับบ้าน (ผู้ซื้อ)
+            </div>
+            <Badge className="rounded-full border border-indigo-200 bg-indigo-50 text-[10px] font-semibold tracking-wide text-indigo-700">
+              Demo Preview
+            </Badge>
+          </div>
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div className="space-y-3 lg:max-w-2xl">
+              <h1 className="text-3xl font-semibold text-slate-900">เตรียมตรวจรับบ้านร่วมกับผู้ขายอย่างมั่นใจ</h1>
+              <p className="text-sm text-slate-600 sm:text-base">
+                หน้านี้จำลองประสบการณ์ของผู้ซื้อที่สามารถเลือกวันนัดหมาย ตรวจรายการเช็คร่วมกับผู้ขาย และรายงานปัญหาเพื่อติดตามกับทีมผู้ขายได้แบบเรียลไทม์
+              </p>
+              <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                <ShieldCheck className="h-4 w-4 text-emerald-500" />
+                DreamHome จะบันทึกการเปลี่ยนแปลงทั้งหมดไว้ในไทม์ไลน์ร่วมกัน
+              </div>
+              <div className="inline-flex items-center gap-2 rounded-xl bg-slate-100 px-4 py-2 text-xs font-medium text-slate-600">
+                <Sparkles className="h-4 w-4 text-indigo-500" />
+                เหมาะสำหรับใช้เป็น Demo โชว์ลูกค้าและผู้มีส่วนเกี่ยวข้อง
+              </div>
+            </div>
+            <Card className="w-full max-w-sm border-none bg-slate-900 text-slate-50 shadow-lg">
+              <CardHeader className="space-y-2">
+                <CardTitle className="flex items-center gap-2 text-base font-semibold">
+                  <CalendarIcon className="h-5 w-5 text-indigo-300" />
+                  วันที่ผู้ซื้อเลือกไว้
+                </CardTitle>
+                <CardDescription className="text-sm text-slate-300">
+                  {displayDateLabel} • {initialPlan.location}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                <div className="space-y-1">
+                  <p className="text-xs uppercase tracking-wide text-slate-400">ผู้ขายติดต่อ</p>
+                  <p className="font-medium text-slate-100">{initialPlan.sellerContact}</p>
+                </div>
+                <div className="rounded-2xl bg-slate-800/70 p-3">
+                  <p className="text-xs text-slate-300">โน้ตถึงผู้ขาย</p>
+                  <Textarea
+                    value={buyerNote}
+                    onChange={(event) => setBuyerNote(event.target.value)}
+                    placeholder="ระบุสิ่งที่ต้องเตรียมหรือคำถามเพิ่มเติม"
+                    className="mt-2 min-h-[72px] border-none bg-transparent text-slate-100 placeholder:text-slate-500"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="preferred-date" className="text-xs text-slate-300">
+                    ปรับวันที่สะดวก
+                  </Label>
+                  <Input
+                    id="preferred-date"
+                    type="date"
+                    value={preferredDate}
+                    onChange={(event) => setPreferredDate(event.target.value)}
+                    className="border-none bg-slate-800 text-slate-100"
+                  />
+                  <p className="text-xs text-slate-400">วันที่ผู้ขายเสนอ: {sellerDateLabel}</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+          <TabsList className="flex w-full flex-wrap justify-start gap-2 bg-transparent p-0">
+            <TabsTrigger value="overview" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium data-[state=active]:border-indigo-600 data-[state=active]:bg-indigo-600 data-[state=active]:text-white">
+              <CalendarIcon className="mr-2 h-4 w-4" /> ภาพรวม
+            </TabsTrigger>
+            <TabsTrigger value="checklist" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium data-[state=active]:border-emerald-600 data-[state=active]:bg-emerald-600 data-[state=active]:text-white">
+              <ClipboardCheck className="mr-2 h-4 w-4" /> เช็คลิสต์ร่วมกัน
+            </TabsTrigger>
+            <TabsTrigger value="issues" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium data-[state=active]:border-purple-600 data-[state=active]:bg-purple-600 data-[state=active]:text-white">
+              <Wrench className="mr-2 h-4 w-4" /> ปัญหา / แจ้งซ่อม
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="overview" className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Card className="border-none bg-white shadow-sm">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base font-semibold text-slate-900">
+                    <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                    สถานะการตรวจของผู้ซื้อ
+                  </CardTitle>
+                  <CardDescription className="text-sm text-slate-600">
+                    ตรวจแล้ว {overviewStats.accepted} รายการ • ขอแก้เพิ่ม {overviewStats.followUp} รายการ
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="h-2 w-full rounded-full bg-slate-200">
+                    <div className="h-2 rounded-full bg-emerald-500" style={{ width: `${overviewStats.completion}%` }} />
+                  </div>
+                  <p className="text-xs text-slate-500">รวม {overviewStats.total} รายการในเช็คลิสต์</p>
+                  <Button asChild variant="outline" className="w-fit border-emerald-200 text-emerald-700 hover:bg-emerald-50">
+                    <Link href="#checklist">ไปที่รายการตรวจ</Link>
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card className="border-none bg-white shadow-sm">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base font-semibold text-slate-900">
+                    <MessageCircle className="h-5 w-5 text-indigo-500" />
+                    ติดต่อผู้ขายได้รวดเร็ว
+                  </CardTitle>
+                  <CardDescription className="text-sm text-slate-600">
+                    บันทึกสิ่งที่ต้องเตรียมและให้ DreamHome แจ้งเตือนผ่านแชทได้ทันที
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2 text-sm text-slate-600">
+                  <div className="flex items-center gap-2">
+                    <Compass className="h-4 w-4 text-slate-500" />
+                    {initialPlan.location}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4 text-slate-500" />
+                    เวลาแนะนำ 09:00 - 11:00 น.
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <ShieldCheck className="h-4 w-4 text-slate-500" />
+                    DreamHome Sync กับฝั่งผู้ขายอัตโนมัติ
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card className="border-none bg-white shadow-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base font-semibold text-slate-900">
+                  <CalendarIcon className="h-5 w-5 text-indigo-500" />
+                  ไทม์ไลน์ล่าสุด
+                </CardTitle>
+                <CardDescription className="text-sm text-slate-600">
+                  ดูเหตุการณ์สำคัญที่ผู้ซื้อและผู้ขายทำร่วมกัน
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {timelineEvents.map((event) => (
+                  <div
+                    key={event.id}
+                    className={`flex flex-col gap-1 rounded-2xl border p-4 text-sm text-slate-700 ${event.tone}`}
+                  >
+                    <p className="font-semibold text-slate-900">{event.title}</p>
+                    <p>{event.description}</p>
+                    <p className="text-xs text-slate-500">{format(parseISO(event.date), "d MMM yyyy")}</p>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="checklist" className="space-y-6" id="checklist">
+            <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+              <div className="space-y-4">
+                {checklistItems.map((item) => (
+                  <Card key={item.id} className="border border-slate-200 bg-white shadow-sm">
+                    <CardHeader className="space-y-2">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <CardTitle className="text-base font-semibold text-slate-900">{item.title}</CardTitle>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${sellerStatusMeta[item.sellerStatus].tone}`}>
+                            {sellerStatusMeta[item.sellerStatus].label}
+                          </Badge>
+                          <Badge className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${buyerStatusMeta[item.buyerStatus].tone}`}>
+                            {buyerStatusMeta[item.buyerStatus].label}
+                          </Badge>
+                        </div>
+                      </div>
+                      <CardDescription className="text-sm text-slate-600">{item.description}</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      <p className="text-xs text-slate-500">อัปเดตล่าสุด {format(parseISO(item.lastUpdatedAt), "d MMM yyyy HH:mm")}</p>
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          size="sm"
+                          variant={item.buyerStatus === "accepted" ? "default" : "outline"}
+                          className={item.buyerStatus === "accepted" ? "bg-emerald-600 text-white hover:bg-emerald-700" : "border-emerald-200 text-emerald-700 hover:bg-emerald-50"}
+                          onClick={() => handleUpdateBuyerStatus(item.id, "accepted")}
+                        >
+                          ยืนยันผ่านแล้ว
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant={item.buyerStatus === "follow-up" ? "default" : "outline"}
+                          className={item.buyerStatus === "follow-up" ? "bg-purple-600 text-white hover:bg-purple-700" : "border-purple-200 text-purple-700 hover:bg-purple-50"}
+                          onClick={() => handleUpdateBuyerStatus(item.id, "follow-up")}
+                        >
+                          ขอให้แก้ไขเพิ่ม
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant={item.buyerStatus === "pending" ? "default" : "outline"}
+                          className={item.buyerStatus === "pending" ? "bg-slate-600 text-white hover:bg-slate-700" : "border-slate-200 text-slate-700 hover:bg-slate-50"}
+                          onClick={() => handleUpdateBuyerStatus(item.id, "pending")}
+                        >
+                          ยังไม่ได้ตรวจ
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+              <Card className="h-fit border border-dashed border-indigo-200 bg-indigo-50 shadow-none">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base font-semibold text-indigo-900">
+                    <ClipboardCheck className="h-5 w-5" />
+                    เพิ่มรายการที่อยากตรวจเพิ่ม
+                  </CardTitle>
+                  <CardDescription className="text-sm text-indigo-700">
+                    ผู้ซื้อสามารถเพิ่มรายการใหม่เพื่อให้ผู้ขายช่วยเตรียมได้
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="new-checklist-title" className="text-xs font-semibold text-indigo-800">
+                      หัวข้อรายการ
+                    </Label>
+                    <Input
+                      id="new-checklist-title"
+                      placeholder="เช่น ตรวจความเรียบร้อยของสวนหน้าบ้าน"
+                      value={newChecklistTitle}
+                      onChange={(event) => setNewChecklistTitle(event.target.value)}
+                      className="border-indigo-200 bg-white"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="new-checklist-description" className="text-xs font-semibold text-indigo-800">
+                      รายละเอียด (ไม่บังคับ)
+                    </Label>
+                    <Textarea
+                      id="new-checklist-description"
+                      placeholder="อธิบายเพิ่มเติมว่าคาดหวังอะไร"
+                      value={newChecklistDescription}
+                      onChange={(event) => setNewChecklistDescription(event.target.value)}
+                      className="border-indigo-200 bg-white"
+                    />
+                  </div>
+                  <Button onClick={handleAddChecklistItem} className="w-full bg-indigo-600 text-white hover:bg-indigo-700">
+                    เพิ่มเข้าเช็คลิสต์
+                  </Button>
+                  <p className="text-xs text-indigo-700/80">
+                    รายการที่เพิ่มจะซิงก์ไปให้ผู้ขายดูผ่าน DreamHome เช่นเดียวกัน
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="issues" className="space-y-6">
+            <div className="flex flex-col gap-4 rounded-3xl bg-white p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-slate-900">แจ้งปัญหาเพิ่มเติม</h2>
+                <p className="text-sm text-slate-600">
+                  บันทึกสิ่งที่พบระหว่างการตรวจรับ ผู้ขายจะเห็นและอัปเดตสถานะได้ทันที
+                </p>
+              </div>
+              <Button onClick={() => setReportDialogOpen(true)} className="bg-purple-600 text-white hover:bg-purple-700">
+                <AlertCircle className="mr-2 h-4 w-4" /> สร้างรายการซ่อม
+              </Button>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {issues.map((issue) => (
+                <Card key={issue.id} className="border border-slate-200 bg-white shadow-sm">
+                  <CardHeader className="space-y-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <CardTitle className="text-base font-semibold text-slate-900">{issue.title}</CardTitle>
+                      <Badge className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${issueStatusMeta[issue.status].tone}`}>
+                        {issueStatusMeta[issue.status].label}
+                      </Badge>
+                    </div>
+                    <CardDescription className="text-sm text-slate-600">{issue.location}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3 text-sm text-slate-600">
+                    <p>{issue.description}</p>
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                      <span>รายงานเมื่อ {format(parseISO(issue.reportedAt), "d MMM yyyy")}</span>
+                      <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-[10px] font-medium text-slate-600">
+                        <ShieldCheck className="h-3 w-3" />
+                        {issue.sellerOwner}
+                      </span>
+                    </div>
+                    {issue.expectedCompletion && (
+                      <p className="text-xs text-slate-500">
+                        กำหนดเสร็จ: {format(parseISO(issue.expectedCompletion), "d MMM yyyy")}
+                      </p>
+                    )}
+                    {issue.resolvedAt && (
+                      <p className="text-xs text-emerald-600">
+                        ปิดงานเมื่อ {format(parseISO(issue.resolvedAt), "d MMM yyyy")}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+              <AlertCircle className="h-5 w-5 text-purple-600" />
+              แจ้งปัญหาใหม่ (Demo)
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="issue-title" className="text-xs font-semibold text-slate-700">
+                หัวข้อปัญหา
+              </Label>
+              <Input
+                id="issue-title"
+                value={reportTitle}
+                onChange={(event) => setReportTitle(event.target.value)}
+                placeholder="เช่น พื้นไม้มีรอยขีด"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="issue-location" className="text-xs font-semibold text-slate-700">
+                ตำแหน่งที่พบ
+              </Label>
+              <Input
+                id="issue-location"
+                value={reportLocation}
+                onChange={(event) => setReportLocation(event.target.value)}
+                placeholder="ระบุห้องหรือบริเวณ"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="issue-description" className="text-xs font-semibold text-slate-700">
+                รายละเอียดเพิ่มเติม
+              </Label>
+              <Textarea
+                id="issue-description"
+                value={reportDescription}
+                onChange={(event) => setReportDescription(event.target.value)}
+                placeholder="อธิบายลักษณะปัญหา หรือแนบรายละเอียดที่อยากแจ้ง"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="issue-expected-date" className="text-xs font-semibold text-slate-700">
+                อยากให้แก้เสร็จภายใน (ไม่บังคับ)
+              </Label>
+              <Input
+                id="issue-expected-date"
+                type="date"
+                value={reportExpectedDate}
+                onChange={(event) => setReportExpectedDate(event.target.value)}
+              />
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setReportDialogOpen(false)}>
+                ยกเลิก
+              </Button>
+              <Button onClick={handleSubmitIssue} className="bg-purple-600 text-white hover:bg-purple-700">
+                บันทึกปัญหา
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/buy/home-inspection/page.tsx
+++ b/app/buy/home-inspection/page.tsx
@@ -1549,223 +1549,222 @@ export default function BuyerHomeInspectionPage() {
           </TabsContent>
         </Tabs>
       </div>
+    </div>
 
-      <Dialog open={notificationsOpen} onOpenChange={setNotificationsOpen}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-              <Bell className="h-5 w-5 text-amber-500" />
-              การแจ้งเตือนทั้งหมด
-            </DialogTitle>
-          </DialogHeader>
-          <div className="max-h-[60vh] space-y-3 overflow-y-auto py-2">
-            {notificationsLoading ? (
-              <div className="flex items-center justify-center py-8 text-sm text-slate-500">
-                กำลังโหลดการแจ้งเตือน...
-              </div>
-            ) : notifications.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
-                ยังไม่มีการแจ้งเตือนจากระบบ
-              </div>
-            ) : (
-              notifications.map((notification) => {
-                const categoryMeta = notificationCategoryMeta[notification.category]
-                return (
-                  <div
-                    key={notification.id}
-                    className={`rounded-2xl border p-4 shadow-sm transition ${
-                      notification.read
-                        ? "border-slate-200 bg-white"
-                        : "border-amber-200 bg-amber-50/70"
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="space-y-2">
-                        <p className="text-sm font-semibold text-slate-900">{notification.title}</p>
-                        <p className="text-sm text-slate-600">{notification.message}</p>
-                        <p className="text-xs text-slate-400">
-                          {safeFormatDateTime(notification.createdAt)} • {" "}
-                          {notification.triggeredBy === "buyer" ? "ผู้ซื้อ" : "ผู้ขาย"}
-                        </p>
-                      </div>
-                      <Badge
-                        className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${categoryMeta.tone}`}
-                      >
-                        {categoryMeta.label}
-                      </Badge>
+    <Dialog open={notificationsOpen} onOpenChange={setNotificationsOpen}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <Bell className="h-5 w-5 text-amber-500" />
+            การแจ้งเตือนทั้งหมด
+          </DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[60vh] space-y-3 overflow-y-auto py-2">
+          {notificationsLoading ? (
+            <div className="flex items-center justify-center py-8 text-sm text-slate-500">
+              กำลังโหลดการแจ้งเตือน...
+            </div>
+          ) : notifications.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
+              ยังไม่มีการแจ้งเตือนจากระบบ
+            </div>
+          ) : (
+            notifications.map((notification) => {
+              const categoryMeta = notificationCategoryMeta[notification.category]
+              return (
+                <div
+                  key={notification.id}
+                  className={`rounded-2xl border p-4 shadow-sm transition ${
+                    notification.read
+                      ? "border-slate-200 bg-white"
+                      : "border-amber-200 bg-amber-50/70"
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-2">
+                      <p className="text-sm font-semibold text-slate-900">{notification.title}</p>
+                      <p className="text-sm text-slate-600">{notification.message}</p>
+                      <p className="text-xs text-slate-400">
+                        {safeFormatDateTime(notification.createdAt)} • {" "}
+                        {notification.triggeredBy === "buyer" ? "ผู้ซื้อ" : "ผู้ขาย"}
+                      </p>
                     </div>
+                    <Badge
+                      className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${categoryMeta.tone}`}
+                    >
+                      {categoryMeta.label}
+                    </Badge>
                   </div>
-                )
-              })
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
 
-      <Dialog
-        open={Boolean(checklistItemToDelete)}
-        onOpenChange={(open) => {
-          if (!open) {
-            setChecklistItemToDelete(null)
-          }
-        }}
-      >
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-base font-semibold text-slate-900">
-              <Trash2 className="h-5 w-5 text-red-500" />
-              ยืนยันการลบรายการตรวจ
-            </DialogTitle>
-            <DialogDescription className="text-sm text-slate-600">
-              {checklistItemToDelete
-                ? `ต้องการลบ "${checklistItemToDelete.title}" ออกจากเช็คลิสต์ใช่หรือไม่?`
-                : "ต้องการลบรายการนี้ออกจากเช็คลิสต์ใช่หรือไม่"}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="flex justify-end gap-2">
+    <Dialog
+      open={Boolean(checklistItemToDelete)}
+      onOpenChange={(open) => {
+        if (!open) {
+          setChecklistItemToDelete(null)
+        }
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-base font-semibold text-slate-900">
+            <Trash2 className="h-5 w-5 text-red-500" />
+            ยืนยันการลบรายการตรวจ
+          </DialogTitle>
+          <DialogDescription className="text-sm text-slate-600">
+            {checklistItemToDelete
+              ? `ต้องการลบ "${checklistItemToDelete.title}" ออกจากเช็คลิสต์ใช่หรือไม่?`
+              : "ต้องการลบรายการนี้ออกจากเช็คลิสต์ใช่หรือไม่"}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setChecklistItemToDelete(null)}
+            className="border-slate-200 text-slate-600 hover:bg-slate-100"
+            disabled={deletingChecklist}
+          >
+            ยกเลิก
+          </Button>
+          <Button
+            onClick={handleConfirmDeleteChecklist}
+            disabled={deletingChecklist}
+            className="bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+          >
+            ลบรายการ
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
+      <DialogContent className="w-[min(95vw,38rem)] max-h-[calc(100vh-4rem)] overflow-y-auto max-w-2xl sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <AlertCircle className="h-5 w-5 text-purple-600" />
+            แจ้งปัญหาใหม่
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="issue-title" className="text-xs font-semibold text-slate-700">
+              หัวข้อปัญหา
+            </Label>
+            <Input
+              id="issue-title"
+              value={reportTitle}
+              onChange={(event) => setReportTitle(event.target.value)}
+              placeholder="เช่น พื้นไม้มีรอยขีด"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="issue-location" className="text-xs font-semibold text-slate-700">
+              ตำแหน่งที่พบ
+            </Label>
+            <Input
+              id="issue-location"
+              value={reportLocation}
+              onChange={(event) => setReportLocation(event.target.value)}
+              placeholder="เช่น ห้องนอนใหญ่"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="issue-description" className="text-xs font-semibold text-slate-700">
+              รายละเอียดเพิ่มเติม (ไม่บังคับ)
+            </Label>
+            <Textarea
+              id="issue-description"
+              value={reportDescription}
+              onChange={(event) => setReportDescription(event.target.value)}
+              placeholder="บรรยายเพิ่มเติมเพื่อให้ทีมผู้ขายเข้าใจปัญหา"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label className="text-xs font-semibold text-slate-700">
+              แนบรูปก่อนแก้ไข (ไม่บังคับ)
+            </Label>
+            <div className="space-y-3 rounded-2xl border border-dashed border-slate-200 p-4">
+              <div className="flex items-center gap-2 text-xs text-slate-500">
+                <Upload className="h-4 w-4 text-slate-400" /> เพิ่มรูปเพื่อให้ผู้ขายเห็นปัญหาชัดเจน
+              </div>
+              <Input
+                ref={beforePhotoInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handleReportBeforePhotoChange}
+                disabled={creatingIssue}
+              />
+              {reportBeforePhotos.length === 0 ? (
+                <p className="text-xs text-slate-500">
+                  เลือกรูปความเสียหายก่อนแก้ไขเพื่อให้ผู้ขายประเมินงานได้ง่ายขึ้น
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {reportBeforePhotos.map((entry) => (
+                    <div
+                      key={entry.preview}
+                      className="relative h-20 w-28 overflow-hidden rounded-lg border border-slate-200"
+                    >
+                      <img
+                        src={entry.preview}
+                        alt="ภาพก่อนแก้ไข"
+                        className="h-full w-full object-cover"
+                      />
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="absolute right-1 top-1 h-6 w-6 rounded-full bg-white/80 text-red-500 hover:bg-white"
+                        onClick={() => handleRemoveBeforePhoto(entry.preview)}
+                        disabled={creatingIssue}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        <span className="sr-only">ลบรูปนี้</span>
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="issue-expected-date" className="text-xs font-semibold text-slate-700">
+              ต้องการให้เสร็จภายใน (ไม่บังคับ)
+            </Label>
+            <Input
+              id="issue-expected-date"
+              type="date"
+              value={reportExpectedDate}
+              onChange={(event) => setReportExpectedDate(event.target.value)}
+            />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
             <Button
               variant="outline"
-              onClick={() => setChecklistItemToDelete(null)}
-              className="border-slate-200 text-slate-600 hover:bg-slate-100"
-              disabled={deletingChecklist}
+              onClick={() => setReportDialogOpen(false)}
+              className="border-slate-200 text-slate-700 hover:bg-slate-100"
+              disabled={creatingIssue}
             >
               ยกเลิก
             </Button>
             <Button
-              onClick={handleConfirmDeleteChecklist}
-              disabled={deletingChecklist}
-              className="bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+              onClick={handleSubmitIssue}
+              disabled={creatingIssue}
+              className="bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-60"
             >
-              ลบรายการ
+              ส่งให้ผู้ขาย
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
-        <DialogContent className="w-[min(95vw,38rem)] max-h-[calc(100vh-4rem)] overflow-y-auto max-w-2xl sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-              <AlertCircle className="h-5 w-5 text-purple-600" />
-              แจ้งปัญหาใหม่
-            </DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
-            <div className="space-y-2">
-              <Label htmlFor="issue-title" className="text-xs font-semibold text-slate-700">
-                หัวข้อปัญหา
-              </Label>
-              <Input
-                id="issue-title"
-                value={reportTitle}
-                onChange={(event) => setReportTitle(event.target.value)}
-                placeholder="เช่น พื้นไม้มีรอยขีด"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="issue-location" className="text-xs font-semibold text-slate-700">
-                ตำแหน่งที่พบ
-              </Label>
-              <Input
-                id="issue-location"
-                value={reportLocation}
-                onChange={(event) => setReportLocation(event.target.value)}
-                placeholder="เช่น ห้องนอนใหญ่"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="issue-description" className="text-xs font-semibold text-slate-700">
-                รายละเอียดเพิ่มเติม (ไม่บังคับ)
-              </Label>
-              <Textarea
-                id="issue-description"
-                value={reportDescription}
-                onChange={(event) => setReportDescription(event.target.value)}
-                placeholder="บรรยายเพิ่มเติมเพื่อให้ทีมผู้ขายเข้าใจปัญหา"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label className="text-xs font-semibold text-slate-700">
-                แนบรูปก่อนแก้ไข (ไม่บังคับ)
-              </Label>
-              <div className="space-y-3 rounded-2xl border border-dashed border-slate-200 p-4">
-                <div className="flex items-center gap-2 text-xs text-slate-500">
-                  <Upload className="h-4 w-4 text-slate-400" /> เพิ่มรูปเพื่อให้ผู้ขายเห็นปัญหาชัดเจน
-                </div>
-                <Input
-                  ref={beforePhotoInputRef}
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  onChange={handleReportBeforePhotoChange}
-                  disabled={creatingIssue}
-                />
-                {reportBeforePhotos.length === 0 ? (
-                  <p className="text-xs text-slate-500">
-                    เลือกรูปความเสียหายก่อนแก้ไขเพื่อให้ผู้ขายประเมินงานได้ง่ายขึ้น
-                  </p>
-                ) : (
-                  <div className="flex flex-wrap gap-2">
-                    {reportBeforePhotos.map((entry) => (
-                      <div
-                        key={entry.preview}
-                        className="relative h-20 w-28 overflow-hidden rounded-lg border border-slate-200"
-                      >
-                        <img
-                          src={entry.preview}
-                          alt="ภาพก่อนแก้ไข"
-                          className="h-full w-full object-cover"
-                        />
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="ghost"
-                          className="absolute right-1 top-1 h-6 w-6 rounded-full bg-white/80 text-red-500 hover:bg-white"
-                          onClick={() => handleRemoveBeforePhoto(entry.preview)}
-                          disabled={creatingIssue}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                          <span className="sr-only">ลบรูปนี้</span>
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="issue-expected-date" className="text-xs font-semibold text-slate-700">
-                ต้องการให้เสร็จภายใน (ไม่บังคับ)
-              </Label>
-              <Input
-                id="issue-expected-date"
-                type="date"
-                value={reportExpectedDate}
-                onChange={(event) => setReportExpectedDate(event.target.value)}
-              />
-            </div>
-            <div className="flex justify-end gap-2 pt-2">
-              <Button
-                variant="outline"
-                onClick={() => setReportDialogOpen(false)}
-                className="border-slate-200 text-slate-700 hover:bg-slate-100"
-                disabled={creatingIssue}
-              >
-                ยกเลิก
-              </Button>
-              <Button
-                onClick={handleSubmitIssue}
-                disabled={creatingIssue}
-                className="bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-60"
-              >
-                ส่งให้ผู้ขาย
-              </Button>
-            </div>
           </div>
-        </DialogContent>
-      </Dialog>
         </div>
-      </div>
-    </>
+      </DialogContent>
+    </Dialog>
+  </>
   )
 }

--- a/app/buy/home-inspection/page.tsx
+++ b/app/buy/home-inspection/page.tsx
@@ -1505,7 +1505,7 @@ export default function BuyerHomeInspectionPage() {
       </Dialog>
 
       <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="w-[min(95vw,38rem)] max-w-2xl sm:max-w-xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
               <AlertCircle className="h-5 w-5 text-purple-600" />

--- a/app/buy/my-properties/page.tsx
+++ b/app/buy/my-properties/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { format, parseISO } from "date-fns";
+import { CheckCircle2, FileText, Home, ListChecks, MapPin } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useAuthContext } from "@/contexts/AuthContext";
+import { useBuyerProperties } from "@/hooks/use-buyer-properties";
+import { formatPropertyPrice, TRANSACTION_LABELS } from "@/lib/property";
+import type { BuyerProperty } from "@/types/buyer-property";
+
+const safeFormatDate = (value: string | null) => {
+  if (!value) return null;
+  try {
+    return format(parseISO(value), "d MMM yyyy");
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return null;
+  }
+};
+
+const safeFormatDateTime = (value: string | null) => {
+  if (!value) return null;
+  try {
+    return format(parseISO(value), "d MMM yyyy HH:mm");
+  } catch (error) {
+    console.error("Failed to format datetime", error);
+    return null;
+  }
+};
+
+const buildLocationLabel = (property: BuyerProperty) => {
+  return [property.address, property.city, property.province]
+    .map((segment) => segment?.trim())
+    .filter(Boolean)
+    .join(", ");
+};
+
+const resolvePriceLabel = (property: BuyerProperty) => {
+  if (property.price == null || property.transactionType == null) return "ราคาไม่ระบุ";
+  return formatPropertyPrice(property.price, property.transactionType);
+};
+
+export default function BuyerPropertiesPage() {
+  const router = useRouter();
+  const { user, loading: authLoading } = useAuthContext();
+  const { properties, loading, error } = useBuyerProperties(user?.uid ?? null);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.replace("/");
+    }
+  }, [authLoading, router, user]);
+
+  const showEmptyState = !loading && properties.length === 0;
+
+  return (
+    <div className="min-h-screen bg-slate-50 py-10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
+        <div className="space-y-3">
+          <div className="inline-flex items-center gap-2 rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+            <Home className="h-4 w-4" />
+            อสังหาที่ซื้อของฉัน
+          </div>
+          <h1 className="text-3xl font-semibold text-slate-900">ติดตามขั้นตอนการซื้อบ้านของคุณได้ที่นี่</h1>
+          <p className="max-w-3xl text-sm text-slate-600 sm:text-base">
+            รวมทุกประกาศที่คุณยืนยันการซื้อ พร้อมสถานะการส่งเอกสาร การตรวจสภาพบ้าน และการส่งมอบ
+            เพื่อให้คุณวางแผนการย้ายเข้าได้อย่างมั่นใจ
+          </p>
+        </div>
+
+        {error && (
+          <Card className="border-amber-200 bg-amber-50">
+            <CardHeader>
+              <CardTitle className="text-base font-semibold text-amber-800">ไม่สามารถโหลดข้อมูลได้</CardTitle>
+              <CardDescription className="text-sm text-amber-700">
+                {error}
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        )}
+
+        {loading ? (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={`buyer-property-skeleton-${index}`}
+                className="h-64 animate-pulse rounded-3xl bg-white shadow-sm"
+              />
+            ))}
+          </div>
+        ) : showEmptyState ? (
+          <Card className="border-none bg-white shadow-sm">
+            <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+              <div className="rounded-full bg-slate-100 p-4">
+                <Home className="h-8 w-8 text-slate-400" />
+              </div>
+              <h2 className="text-xl font-semibold text-slate-900">ยังไม่มีรายการที่ยืนยันการซื้อ</h2>
+              <p className="max-w-md text-sm text-slate-600">
+                เริ่มต้นคุยกับผู้ขายผ่านแชทเพื่อยืนยันการซื้อ เมื่อผู้ขายอนุมัติ ระบบจะแสดงทรัพย์ที่นี่พร้อมขั้นตอนถัดไปให้คุณทันที
+              </p>
+              <Button asChild className="bg-indigo-600 text-white hover:bg-indigo-700">
+                <Link href="/buy">ค้นหาบ้านที่สนใจ</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {properties.map((property) => {
+              const locationLabel = buildLocationLabel(property);
+              const priceLabel = resolvePriceLabel(property);
+              const confirmedAtLabel = safeFormatDateTime(property.confirmedAt);
+              const handoverDateLabel = safeFormatDate(property.handoverDate);
+
+              const transactionLabel = property.transactionType
+                ? TRANSACTION_LABELS[property.transactionType] ?? property.transactionType
+                : null;
+
+              return (
+                <Card key={property.id} className="overflow-hidden border-none bg-white shadow-sm">
+                  <div className="flex flex-col gap-6 p-6 sm:flex-row sm:items-start">
+                    <div className="w-full sm:w-52">
+                      <div className="relative h-40 w-full overflow-hidden rounded-2xl bg-slate-100 sm:h-48">
+                        {property.thumbnailUrl ? (
+                          <Image
+                            src={property.thumbnailUrl}
+                            alt={property.title}
+                            fill
+                            sizes="(min-width: 768px) 200px, 100vw"
+                            className="object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-slate-400">
+                            <Home className="h-8 w-8" />
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex flex-1 flex-col gap-4">
+                      <div className="space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          {transactionLabel && (
+                            <Badge className="rounded-full bg-indigo-600 text-white">
+                              {transactionLabel}
+                            </Badge>
+                          )}
+                          <Badge className="rounded-full bg-emerald-50 text-emerald-700">
+                            ยืนยันแล้ว
+                          </Badge>
+                          {property.sellerDocumentsConfirmed && (
+                            <Badge className="rounded-full bg-blue-50 text-blue-700">
+                              ผู้ขายตรวจเอกสารแล้ว
+                            </Badge>
+                          )}
+                        </div>
+                        <h2 className="text-2xl font-semibold text-slate-900">{property.title}</h2>
+                        <p className="text-lg font-medium text-indigo-600">{priceLabel}</p>
+                        {locationLabel && (
+                          <div className="flex items-center gap-2 text-sm text-slate-600">
+                            <MapPin className="h-4 w-4" />
+                            {locationLabel}
+                          </div>
+                        )}
+                        {confirmedAtLabel && (
+                          <p className="text-xs text-slate-500">
+                            ยืนยันเมื่อ {confirmedAtLabel}
+                          </p>
+                        )}
+                      </div>
+
+                      <div className="grid gap-3 rounded-2xl bg-slate-50 p-4 sm:grid-cols-2">
+                        <div className="space-y-1 text-sm text-slate-600">
+                          <p className="flex items-center gap-2 font-semibold text-slate-800">
+                            <FileText className="h-4 w-4 text-indigo-500" />
+                            การส่งเอกสาร
+                          </p>
+                          <p>
+                            {property.sellerDocumentsConfirmed
+                              ? "ผู้ขายตรวจสอบเอกสารเรียบร้อย รอนัดส่งตัวจริง"
+                              : "เตรียมเอกสารให้ครบและส่งให้ผู้ขายตรวจสอบ"}
+                          </p>
+                        </div>
+                        <div className="space-y-1 text-sm text-slate-600">
+                          <p className="flex items-center gap-2 font-semibold text-slate-800">
+                            <ListChecks className="h-4 w-4 text-emerald-500" />
+                            นัดหมายตรวจและส่งมอบ
+                          </p>
+                          <p>
+                            {handoverDateLabel
+                              ? `นัดหมายส่งมอบวันที่ ${handoverDateLabel}`
+                              : "กำหนดวันตรวจและส่งมอบร่วมกับผู้ขาย"}
+                          </p>
+                          {property.handoverNote && (
+                            <p className="text-xs text-slate-500">โน้ต: {property.handoverNote}</p>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          asChild
+                          className="bg-indigo-600 text-white hover:bg-indigo-700"
+                        >
+                          <Link href={`/buy/send-documents?propertyId=${property.propertyId}`}>
+                            ส่งเอกสาร
+                          </Link>
+                        </Button>
+                        <Button
+                          asChild
+                          variant="outline"
+                          className="border-emerald-200 text-emerald-700 hover:bg-emerald-50"
+                        >
+                          <Link href={`/buy/home-inspection?propertyId=${property.propertyId}`}>
+                            เช็คสภาพบ้าน
+                          </Link>
+                        </Button>
+                        <Button
+                          asChild
+                          variant="outline"
+                          className="border-slate-200 text-slate-700 hover:bg-slate-100"
+                        >
+                          <Link href={`/buy/home-inspection?propertyId=${property.propertyId}#timeline`}>
+                            ติดตามการส่งบ้าน
+                          </Link>
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+
+        <Card className="border-none bg-slate-900 text-slate-100">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+              <CheckCircle2 className="h-5 w-5 text-emerald-400" />
+              เคล็ดลับการเตรียมส่งมอบบ้านให้ราบรื่น
+            </CardTitle>
+            <CardDescription className="text-sm text-slate-300">
+              สรุปขั้นตอนสำคัญเพื่อให้ทั้งผู้ซื้อและผู้ขายเห็นภาพรวมเดียวกัน
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-2xl bg-slate-800/60 p-4 text-sm">
+              <p className="font-semibold text-slate-100">1. รวบรวมเอกสาร</p>
+              <p className="mt-2 text-slate-300">
+                ตรวจสอบเอกสารตามรายการที่ DreamHome แนะนำ และอัปเดตผู้ขายเมื่อพร้อมส่งมอบตัวจริง
+              </p>
+            </div>
+            <div className="rounded-2xl bg-slate-800/60 p-4 text-sm">
+              <p className="font-semibold text-slate-100">2. นัดหมายตรวจสภาพบ้าน</p>
+              <p className="mt-2 text-slate-300">
+                บันทึกวันที่สะดวกและสิ่งที่ต้องเตรียม ผู้ขายจะได้รับแจ้งเตือนและยืนยันการนัดหมายให้ทันที
+              </p>
+            </div>
+            <div className="rounded-2xl bg-slate-800/60 p-4 text-sm">
+              <p className="font-semibold text-slate-100">3. ปิดงานส่งมอบ</p>
+              <p className="mt-2 text-slate-300">
+                ติดตามงานแก้ไข ตรวจสอบสถานะการส่งมอบ และเก็บหลักฐานไว้ในระบบเพื่อการอ้างอิงในอนาคต
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/buy/my-properties/page.tsx
+++ b/app/buy/my-properties/page.tsx
@@ -183,7 +183,7 @@ export default function BuyerPropertiesPage() {
               const locationLabel = buildLocationLabel(property);
               const priceLabel = resolvePriceLabel(property);
               const confirmedAtLabel = safeFormatDateTime(property.confirmedAt);
-              const handoverDateLabel = safeFormatDate(property.handoverDate);
+              const handoverDateLabel = safeFormatDateTime(property.handoverDate);
 
               const transactionLabel = property.transactionType
                 ? TRANSACTION_LABELS[property.transactionType] ?? property.transactionType

--- a/app/buy/send-documents/page.tsx
+++ b/app/buy/send-documents/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
-import { AlertCircle, CheckCircle2, ClipboardList, FileText, NotebookPen } from "lucide-react"
+import { AlertCircle, ArrowRight, CheckCircle2, ClipboardList, FileText, NotebookPen } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -165,9 +165,27 @@ export default function BuyerSendDocumentsPage() {
                   </div>
                 )}
                 {sellerConfirmed && (
-                  <div className="inline-flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-2 text-xs font-semibold text-emerald-600">
-                    <CheckCircle2 className="h-4 w-4" />
-                    ผู้ขายพร้อมรับเอกสารตัวจริงแล้ว
+                  <div className="flex flex-wrap items-center gap-3">
+                    <div className="inline-flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-2 text-xs font-semibold text-emerald-600">
+                      <CheckCircle2 className="h-4 w-4" />
+                      ผู้ขายพร้อมรับเอกสารตัวจริงแล้ว
+                    </div>
+                    <Button
+                      asChild
+                      size="sm"
+                      className="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-4 py-2 text-xs font-semibold text-white hover:bg-emerald-700"
+                    >
+                      <Link
+                        href={
+                          propertyId
+                            ? `/buy/home-inspection?propertyId=${propertyId}`
+                            : "/buy/home-inspection"
+                        }
+                      >
+                        ไปหน้า Demo ตรวจรับบ้าน
+                        <ArrowRight className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
                   </div>
                 )}
               </div>

--- a/app/buy/send-documents/page.tsx
+++ b/app/buy/send-documents/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import { AlertCircle, ArrowRight, CheckCircle2, ClipboardList, FileText, NotebookPen } from "lucide-react"
@@ -16,7 +16,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { useAuthContext } from "@/contexts/AuthContext"
+import { useToast } from "@/hooks/use-toast"
 import { subscribeToDocument } from "@/lib/firestore"
+import { cancelPropertyPurchase } from "@/lib/property-purchase"
 
 interface DocumentItem {
   id: string
@@ -65,10 +67,20 @@ export default function BuyerSendDocumentsPage() {
   const propertyId = searchParams.get("propertyId")
   const router = useRouter()
   const { user, loading } = useAuthContext()
+  const { toast } = useToast()
 
   const [sellerConfirmed, setSellerConfirmed] = useState(false)
   const [modalDismissed, setModalDismissed] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false)
+  const [cancelling, setCancelling] = useState(false)
+  const [propertyMeta, setPropertyMeta] = useState<{
+    sellerUid: string | null
+    confirmedBuyerId: string | null
+    isUnderPurchase: boolean
+    title: string | null
+  } | null>(null)
+  const propertyGuardRef = useRef(false)
 
   const progressPreview = useMemo(() => {
     return `${REQUIRED_DOCUMENTS.length} เอกสารหลัก + ${OPTIONAL_DOCUMENTS.length} เอกสารเพิ่มเติม`
@@ -77,6 +89,7 @@ export default function BuyerSendDocumentsPage() {
   useEffect(() => {
     if (!propertyId) {
       setSellerConfirmed(false)
+      setPropertyMeta(null)
       return
     }
 
@@ -89,7 +102,23 @@ export default function BuyerSendDocumentsPage() {
           if (!isMounted) return
           const data = (doc?.data() as Record<string, unknown> | null) ?? null
           const confirmed = Boolean(data?.sellerDocumentsConfirmed)
+          const confirmedBuyerId =
+            typeof data?.confirmedBuyerId === "string" && data.confirmedBuyerId.trim().length > 0
+              ? (data.confirmedBuyerId as string)
+              : null
           setSellerConfirmed(confirmed)
+          setPropertyMeta({
+            sellerUid:
+              typeof data?.userUid === "string" && data.userUid.trim().length > 0
+                ? (data.userUid as string)
+                : null,
+            confirmedBuyerId,
+            isUnderPurchase: Boolean(data?.isUnderPurchase),
+            title:
+              typeof data?.title === "string" && data.title.trim().length > 0
+                ? (data.title as string)
+                : null,
+          })
         })
       } catch (error) {
         console.error("Failed to subscribe buyer send documents", error)
@@ -121,6 +150,76 @@ export default function BuyerSendDocumentsPage() {
     }
   }, [loading, router, user])
 
+  useEffect(() => {
+    if (!propertyMeta) return
+    if (!user?.uid) return
+
+    if (propertyMeta.isUnderPurchase && propertyMeta.confirmedBuyerId === user.uid) {
+      propertyGuardRef.current = false
+      return
+    }
+
+    if (!propertyGuardRef.current) {
+      propertyGuardRef.current = true
+      toast({
+        variant: "destructive",
+        title: "ไม่สามารถเข้าถึงประกาศนี้ได้",
+        description: "ประกาศนี้ไม่อยู่ในขั้นตอนการซื้อของคุณแล้ว",
+      })
+      router.replace("/buy/my-properties")
+    }
+  }, [propertyMeta, router, toast, user?.uid])
+
+  const handleCancelPurchase = async () => {
+    if (!propertyId) {
+      toast({
+        variant: "destructive",
+        title: "ไม่พบประกาศ",
+        description: "กรุณาเปิดลิงก์จากประกาศอีกครั้ง",
+      })
+      return
+    }
+
+    if (!user?.uid) {
+      toast({
+        variant: "destructive",
+        title: "ไม่สามารถยกเลิกได้",
+        description: "กรุณาเข้าสู่ระบบก่อน",
+      })
+      return
+    }
+
+    if (!propertyMeta || propertyMeta.confirmedBuyerId !== user.uid) {
+      toast({
+        variant: "destructive",
+        title: "ยกเลิกไม่สำเร็จ",
+        description: "ประกาศนี้ไม่ได้อยู่ในรายการของคุณ",
+      })
+      return
+    }
+
+    setCancelling(true)
+    try {
+      await cancelPropertyPurchase(propertyId, "buyer")
+      propertyGuardRef.current = true
+      toast({
+        title: "ยกเลิกการซื้อเรียบร้อย",
+        description: "ระบบได้คืนสถานะประกาศและล้างข้อมูลการตรวจแล้ว",
+      })
+      setCancelDialogOpen(false)
+      router.replace("/buy/my-properties")
+    } catch (error) {
+      console.error("Failed to cancel property purchase", error)
+      toast({
+        variant: "destructive",
+        title: "ยกเลิกไม่สำเร็จ",
+        description: error instanceof Error ? error.message : "กรุณาลองใหม่อีกครั้ง",
+      })
+    } finally {
+      setCancelling(false)
+    }
+  }
+
   return (
     <>
       <Dialog open={modalOpen} onOpenChange={handleCloseModal}>
@@ -137,6 +236,31 @@ export default function BuyerSendDocumentsPage() {
           <DialogFooter className="sm:justify-end">
             <Button onClick={() => handleCloseModal(false)} className="bg-blue-600 text-white hover:bg-blue-700">
               รับทราบ
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-semibold text-slate-900">
+              ยกเลิกการซื้อบ้านนี้หรือไม่?
+            </DialogTitle>
+            <DialogDescription className="text-sm text-slate-600">
+              ระบบจะลบข้อมูลการส่งเอกสารและการตรวจสภาพทั้งหมด เพื่อคืนสถานะประกาศให้ผู้ซื้อรายอื่น
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={() => setCancelDialogOpen(false)}>
+              กลับไปก่อน
+            </Button>
+            <Button
+              onClick={handleCancelPurchase}
+              disabled={cancelling}
+              className="bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+            >
+              {cancelling ? "กำลังยกเลิก..." : "ยืนยันการยกเลิก"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -188,6 +312,14 @@ export default function BuyerSendDocumentsPage() {
                     </Button>
                   </div>
                 )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setCancelDialogOpen(true)}
+                  className="mt-2 inline-flex items-center gap-2 rounded-full border-red-200 text-xs font-semibold text-red-600 hover:bg-red-50"
+                >
+                  ยกเลิกรายการซื้อ
+                </Button>
               </div>
               <div className="flex flex-col items-start gap-2 rounded-2xl bg-blue-50 px-4 py-3 text-sm text-blue-700">
                 <div className="flex items-center gap-2 font-semibold">

--- a/app/buy/send-documents/page.tsx
+++ b/app/buy/send-documents/page.tsx
@@ -316,7 +316,7 @@ export default function BuyerSendDocumentsPage() {
                   type="button"
                   variant="outline"
                   onClick={() => setCancelDialogOpen(true)}
-                  className="mt-2 inline-flex items-center gap-2 rounded-full border-red-200 text-xs font-semibold text-red-600 hover:bg-red-50"
+                  className="mt-4 inline-flex items-center gap-2 rounded-xl border-red-200 px-4 py-2 text-xs font-semibold text-red-600 hover:bg-red-50"
                 >
                   ยกเลิกรายการซื้อ
                 </Button>

--- a/app/buy/send-documents/page.tsx
+++ b/app/buy/send-documents/page.tsx
@@ -182,7 +182,7 @@ export default function BuyerSendDocumentsPage() {
                             : "/buy/home-inspection"
                         }
                       >
-                        ไปหน้า Demo ตรวจรับบ้าน
+                        ไปหน้าตรวจรับบ้านจริง
                         <ArrowRight className="h-3.5 w-3.5" />
                       </Link>
                     </Button>

--- a/app/sell/home-inspection/page.tsx
+++ b/app/sell/home-inspection/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -369,9 +370,14 @@ export default function SellerHomeInspectionPage() {
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-3">
-            <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
-              <Home className="h-4 w-4" />
-              ขั้นตอนส่งมอบบ้าน
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                <Home className="h-4 w-4" />
+                ขั้นตอนส่งมอบบ้าน (ผู้ขาย)
+              </div>
+              <Badge className="rounded-full border border-blue-200 bg-blue-50 text-[10px] font-semibold tracking-wide text-blue-700">
+                Demo Flow
+              </Badge>
             </div>
             <h1 className="text-3xl font-semibold text-gray-900">
               กำหนดวันส่งมอบและตรวจเช็คสภาพบ้าน

--- a/app/sell/home-inspection/page.tsx
+++ b/app/sell/home-inspection/page.tsx
@@ -1681,7 +1681,7 @@ export default function SellerHomeInspectionPage() {
       </Dialog>
 
       <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
-        <DialogContent className="w-[min(95vw,38rem)] max-w-2xl sm:max-w-xl">
+        <DialogContent className="w-[min(95vw,38rem)] max-h-[calc(100vh-4rem)] overflow-y-auto max-w-2xl sm:max-w-xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
               <AlertCircle className="h-5 w-5 text-purple-600" />

--- a/app/sell/home-inspection/page.tsx
+++ b/app/sell/home-inspection/page.tsx
@@ -1,0 +1,844 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { format, parseISO } from "date-fns";
+import {
+  AlertCircle,
+  Calendar as CalendarIcon,
+  Check,
+  CheckCircle2,
+  ClipboardCheck,
+  ClipboardList,
+  Clock,
+  Home,
+  Images as ImagesIcon,
+  MessageCircle,
+  Plus,
+  ShieldCheck,
+  Wrench,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+
+interface InspectionChecklistItem {
+  id: string;
+  title: string;
+  description: string;
+  status: "pending" | "passed" | "issue";
+  createdBy: "buyer" | "seller";
+  lastUpdatedAt: string;
+}
+
+interface DefectIssue {
+  id: string;
+  title: string;
+  location: string;
+  description: string;
+  status: DefectStatus;
+  reportedBy: "buyer" | "seller";
+  reportedAt: string;
+  expectedCompletion?: string;
+  resolvedAt?: string;
+  attachments?: number;
+}
+
+type DefectStatus = "pending" | "in-progress" | "verified" | "completed";
+
+const defectStatusMeta: Record<DefectStatus, { label: string; badgeClass: string; progressColor: string }> = {
+  pending: {
+    label: "รอดำเนินการ",
+    badgeClass: "bg-amber-100 text-amber-700 border border-amber-200",
+    progressColor: "bg-amber-500",
+  },
+  "in-progress": {
+    label: "กำลังแก้ไข",
+    badgeClass: "bg-blue-100 text-blue-700 border border-blue-200",
+    progressColor: "bg-blue-500",
+  },
+  verified: {
+    label: "รอตรวจสอบ",
+    badgeClass: "bg-purple-100 text-purple-700 border border-purple-200",
+    progressColor: "bg-purple-500",
+  },
+  completed: {
+    label: "แก้ไขเสร็จ",
+    badgeClass: "bg-emerald-100 text-emerald-700 border border-emerald-200",
+    progressColor: "bg-emerald-500",
+  },
+};
+
+const initialChecklist: InspectionChecklistItem[] = [
+  {
+    id: "exterior",
+    title: "ตรวจรอบนอกอาคาร",
+    description: "ผนังภายนอก สี และรอยแตกร้าว",
+    status: "pending",
+    createdBy: "seller",
+    lastUpdatedAt: new Date().toISOString(),
+  },
+  {
+    id: "plumbing",
+    title: "ระบบน้ำและท่อ",
+    description: "แรงดันน้ำ การรั่วซึม และสุขภัณฑ์",
+    status: "pending",
+    createdBy: "buyer",
+    lastUpdatedAt: new Date().toISOString(),
+  },
+  {
+    id: "electric",
+    title: "ระบบไฟฟ้า",
+    description: "สวิตช์ ปลั๊กไฟ และตู้ควบคุม",
+    status: "pending",
+    createdBy: "seller",
+    lastUpdatedAt: new Date().toISOString(),
+  },
+];
+
+const initialIssues: DefectIssue[] = [
+  {
+    id: "kitchen-faucet",
+    title: "ก็อกน้ำห้องครัวหยด",
+    location: "ห้องครัว",
+    description: "น้ำหยดจากหัวก็อกครัวตลอดเวลา",
+    status: "in-progress",
+    reportedBy: "buyer",
+    reportedAt: new Date().toISOString(),
+    expectedCompletion: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+    attachments: 2,
+  },
+  {
+    id: "bathroom-tile",
+    title: "กระเบื้องห้องน้ำร้าว",
+    location: "ห้องน้ำชั้นบน",
+    description: "รอยร้าวยาว 10 ซม. บริเวณพื้น",
+    status: "pending",
+    reportedBy: "buyer",
+    reportedAt: new Date().toISOString(),
+    expectedCompletion: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+    attachments: 1,
+  },
+];
+
+export default function SellerHomeInspectionPage() {
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<string>("schedule");
+  const [handoverDate, setHandoverDate] = useState<string>("");
+  const [handoverNote, setHandoverNote] = useState<string>("");
+  const [checklistItems, setChecklistItems] = useState<InspectionChecklistItem[]>(initialChecklist);
+  const [issues, setIssues] = useState<DefectIssue[]>(initialIssues);
+  const [newChecklistTitle, setNewChecklistTitle] = useState("");
+  const [newChecklistDescription, setNewChecklistDescription] = useState("");
+  const [newChecklistOwner, setNewChecklistOwner] = useState<"buyer" | "seller">("buyer");
+  const [reportDialogOpen, setReportDialogOpen] = useState(false);
+  const [reportSourceId, setReportSourceId] = useState<string | null>(null);
+  const [reportTitle, setReportTitle] = useState("");
+  const [reportDescription, setReportDescription] = useState("");
+  const [reportLocation, setReportLocation] = useState("");
+  const [reportExpectedDate, setReportExpectedDate] = useState("");
+  const [reportBy, setReportBy] = useState<"buyer" | "seller">("buyer");
+
+  const handoverConfirmed = Boolean(handoverDate);
+
+  const handleConfirmHandover = () => {
+    if (!handoverDate) {
+      toast({
+        variant: "destructive",
+        title: "กรุณาระบุวันที่ส่งมอบบ้าน",
+        description: "เลือกวันที่คาดว่าจะส่งมอบบ้านเพื่อแจ้งให้ผู้เกี่ยวข้องทราบ",
+      });
+      return;
+    }
+
+    toast({
+      title: "บันทึกวันส่งมอบเรียบร้อย",
+      description: "ระบบได้แจ้งเตือนวันส่งมอบในแชทของทีมงานแล้ว",
+    });
+
+    setActiveTab("inspection");
+
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("dreamhome:open-chat", {
+          detail: {
+            systemMessage: `ผู้ขายยืนยันวันส่งมอบบ้านเป็นวันที่ ${format(parseISO(handoverDate), "d MMM yyyy")}`,
+          },
+        }),
+      );
+    }
+  };
+
+  const handleAddChecklistItem = () => {
+    if (!newChecklistTitle.trim()) {
+      toast({
+        variant: "destructive",
+        title: "กรุณากรอกหัวข้อ",
+        description: "ระบุหัวข้อรายการตรวจเช็คก่อนบันทึก",
+      });
+      return;
+    }
+
+    const item: InspectionChecklistItem = {
+      id: `${Date.now()}`,
+      title: newChecklistTitle.trim(),
+      description: newChecklistDescription.trim(),
+      createdBy: newChecklistOwner,
+      status: "pending",
+      lastUpdatedAt: new Date().toISOString(),
+    };
+
+    setChecklistItems((prev) => [item, ...prev]);
+    setNewChecklistTitle("");
+    setNewChecklistDescription("");
+    toast({
+      title: "เพิ่มรายการตรวจเช็คแล้ว",
+      description: `${item.createdBy === "buyer" ? "ผู้ซื้อ" : "ผู้ขาย"} เป็นผู้เพิ่มรายการนี้`,
+    });
+  };
+
+  const handleChecklistStatus = (id: string, status: "passed" | "issue") => {
+    setChecklistItems((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? { ...item, status, lastUpdatedAt: new Date().toISOString() }
+          : item,
+      ),
+    );
+
+    if (status === "passed") {
+      toast({
+        title: "บันทึกผลตรวจเช็ค",
+        description: "รายการนี้ผ่านการตรวจเช็คเรียบร้อย",
+      });
+    } else {
+      const source = checklistItems.find((item) => item.id === id);
+      setReportSourceId(id);
+      setReportTitle(source ? source.title : "");
+      setReportDescription(source ? source.description : "");
+      setReportLocation("");
+      setReportExpectedDate("");
+      setReportBy("buyer");
+      setReportDialogOpen(true);
+    }
+  };
+
+  const handleOpenReport = () => {
+    setReportSourceId(null);
+    setReportTitle("");
+    setReportDescription("");
+    setReportLocation("");
+    setReportExpectedDate("");
+    setReportBy("buyer");
+    setReportDialogOpen(true);
+  };
+
+  const handleSubmitReport = () => {
+    if (!reportTitle.trim()) {
+      toast({
+        variant: "destructive",
+        title: "กรุณาระบุหัวข้อปัญหา",
+        description: "ใส่หัวข้อสั้น ๆ เพื่อให้ทีมงานเข้าใจประเด็นที่พบ",
+      });
+      return;
+    }
+
+    const newIssue: DefectIssue = {
+      id: `${Date.now()}`,
+      title: reportTitle.trim(),
+      description: reportDescription.trim() || "-",
+      location: reportLocation.trim() || "ไม่ระบุ",
+      status: "pending",
+      reportedBy: reportBy,
+      reportedAt: new Date().toISOString(),
+      expectedCompletion: reportExpectedDate ? parseISO(reportExpectedDate).toISOString() : undefined,
+      attachments: 0,
+    };
+
+    setIssues((prev) => [newIssue, ...prev]);
+
+    if (reportSourceId) {
+      setChecklistItems((prev) =>
+        prev.map((item) =>
+          item.id === reportSourceId
+            ? { ...item, status: "issue", lastUpdatedAt: new Date().toISOString() }
+            : item,
+        ),
+      );
+    }
+
+    setReportDialogOpen(false);
+    toast({
+      title: "ส่งรายงานปัญหาแล้ว",
+      description: "ระบบได้สร้างบัตรติดตามใน Defect Tracking ให้เรียบร้อย",
+    });
+  };
+
+  const handleIssueStatusChange = (id: string, status: DefectStatus) => {
+    setIssues((prev) =>
+      prev.map((issue) =>
+        issue.id === id
+          ? {
+              ...issue,
+              status,
+              resolvedAt:
+                status === "completed" ? new Date().toISOString() : issue.resolvedAt,
+            }
+          : issue,
+      ),
+    );
+
+    toast({
+      title: "อัปเดตสถานะปัญหา",
+      description: `ตั้งสถานะเป็น ${defectStatusMeta[status].label} แล้ว`,
+    });
+  };
+
+  const overallProgress = useMemo(() => {
+    if (issues.length === 0) return 100;
+    const completed = issues.filter((issue) => issue.status === "completed").length;
+    return Math.round((completed / issues.length) * 100);
+  }, [issues.length, issues]);
+
+  const issueStatusCounts = useMemo(
+    () =>
+      issues.reduce(
+        (acc, issue) => {
+          acc[issue.status] += 1;
+          return acc;
+        },
+        {
+          pending: 0,
+          "in-progress": 0,
+          verified: 0,
+          completed: 0,
+        } as Record<DefectStatus, number>,
+      ),
+    [issues],
+  );
+
+  const calendarEvents = useMemo(() => {
+    const events: { id: string; title: string; date: string; type: "handover" | "report" | "resolved" }[] = [];
+
+    if (handoverDate) {
+      events.push({
+        id: "handover",
+        title: "วันส่งมอบบ้าน",
+        date: handoverDate,
+        type: "handover",
+      });
+    }
+
+    issues.forEach((issue) => {
+      events.push({
+        id: `${issue.id}-reported`,
+        title: `แจ้งปัญหา: ${issue.title}`,
+        date: issue.reportedAt,
+        type: "report",
+      });
+
+      if (issue.resolvedAt) {
+        events.push({
+          id: `${issue.id}-resolved`,
+          title: `แก้ไขเสร็จ: ${issue.title}`,
+          date: issue.resolvedAt,
+          type: "resolved",
+        });
+      }
+    });
+
+    return events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }, [handoverDate, issues]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-3">
+            <div className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+              <Home className="h-4 w-4" />
+              ขั้นตอนส่งมอบบ้าน
+            </div>
+            <h1 className="text-3xl font-semibold text-gray-900">
+              กำหนดวันส่งมอบและตรวจเช็คสภาพบ้าน
+            </h1>
+            <p className="max-w-2xl text-sm text-gray-600">
+              เมื่อยืนยันวันส่งมอบแล้ว ระบบจะพาคุณไปยังรายการตรวจเช็คสภาพบ้านเพื่อให้ผู้ซื้อและผู้ขายร่วมกันตรวจสอบ พร้อมรายงานปัญหาและติดตามความคืบหน้าได้ทันที
+            </p>
+            {handoverConfirmed && (
+              <div className="inline-flex items-center gap-2 rounded-xl bg-emerald-50 px-4 py-2 text-xs font-semibold text-emerald-700">
+                <CheckCircle2 className="h-4 w-4" />
+                ยืนยันวันส่งมอบแล้ว: {format(parseISO(handoverDate), "d MMM yyyy")}
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col items-start gap-2 rounded-2xl bg-white p-5 shadow-sm">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+              ภาพรวม Defect
+            </p>
+            <div className="flex items-baseline gap-2">
+              <span className="text-3xl font-bold text-gray-900">{overallProgress}%</span>
+              <span className="text-sm text-gray-500">ปัญหาแก้ไขแล้ว</span>
+            </div>
+            <div className="h-2 w-40 rounded-full bg-slate-200">
+              <div
+                className="h-2 rounded-full bg-emerald-500 transition-all"
+                style={{ width: `${overallProgress}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-500">
+              รวม {issues.length} ประเด็นที่ต้องติดตาม
+            </p>
+          </div>
+        </div>
+
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
+          <TabsList className="flex w-full flex-wrap justify-start gap-2 bg-transparent p-0">
+            <TabsTrigger value="schedule" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium data-[state=active]:border-blue-600 data-[state=active]:bg-blue-600 data-[state=active]:text-white">
+              <CalendarIcon className="mr-2 h-4 w-4" /> นัดหมายส่งมอบ
+            </TabsTrigger>
+            <TabsTrigger value="inspection" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium data-[state=active]:border-emerald-600 data-[state=active]:bg-emerald-600 data-[state=active]:text-white">
+              <ClipboardCheck className="mr-2 h-4 w-4" /> ตรวจสภาพบ้าน
+            </TabsTrigger>
+            <TabsTrigger value="defects" className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium data-[state=active]:border-purple-600 data-[state=active]:bg-purple-600 data-[state=active]:text-white">
+              <Wrench className="mr-2 h-4 w-4" /> Defect Tracking
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="schedule" className="space-y-6">
+            <Card className="border-none shadow-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl font-semibold text-gray-900">
+                  <CalendarIcon className="h-5 w-5 text-blue-500" />
+                  ยืนยันวันส่งมอบบ้าน
+                </CardTitle>
+                <CardDescription className="text-sm text-gray-600">
+                  เลือกวันที่คาดว่าจะส่งมอบบ้าน เพื่อให้ผู้ซื้อและทีมงานเตรียมความพร้อม รวมถึงสามารถแก้ไขภายหลังได้ตามสถานการณ์จริง
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-6 sm:grid-cols-2">
+                <div className="space-y-3">
+                  <Label htmlFor="handover-date" className="text-sm font-medium text-gray-700">
+                    วันที่ส่งมอบ (โดยประมาณ)
+                  </Label>
+                  <Input
+                    id="handover-date"
+                    type="date"
+                    value={handoverDate}
+                    onChange={(event) => setHandoverDate(event.target.value)}
+                    min={new Date().toISOString().split("T")[0]}
+                  />
+                  <p className="text-xs text-gray-500">
+                    สามารถแก้ไขวันที่ภายหลังได้ หากมีการเปลี่ยนแปลงจากผู้พัฒนาโครงการหรือทีมงาน
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <Label htmlFor="handover-note" className="text-sm font-medium text-gray-700">
+                    รายละเอียดเพิ่มเติม (ถ้ามี)
+                  </Label>
+                  <Textarea
+                    id="handover-note"
+                    rows={4}
+                    placeholder="เช่น ต้องการให้ผู้ซื้อเตรียมบัตรประชาชนตัวจริง หรือ นัดหมายช่วงเวลาเช้า"
+                    value={handoverNote}
+                    onChange={(event) => setHandoverNote(event.target.value)}
+                  />
+                </div>
+              </CardContent>
+              <CardFooter className="flex flex-col justify-between gap-4 border-t border-slate-100 pt-6 sm:flex-row sm:items-center">
+                <div className="text-sm text-gray-600">
+                  เมื่อกดยืนยัน ระบบจะส่งการแจ้งเตือนในแชท และสามารถย้อนกลับมาแก้ไขได้ทุกเมื่อ
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button className="bg-blue-600 text-white hover:bg-blue-700" onClick={handleConfirmHandover}>
+                    {handoverConfirmed ? "อัปเดตวันส่งมอบ" : "ยืนยันวันส่งมอบ"}
+                  </Button>
+                  {handoverConfirmed && (
+                    <Button
+                      variant="outline"
+                      onClick={() => setActiveTab("inspection")}
+                      className="border-blue-200 text-blue-600 hover:bg-blue-50"
+                    >
+                      ไปยังรายการตรวจเช็ค
+                    </Button>
+                  )}
+                </div>
+              </CardFooter>
+            </Card>
+
+            <Card className="border-none bg-blue-50/70 shadow-none">
+              <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3 text-sm text-blue-700">
+                  <MessageCircle className="h-5 w-5" />
+                  ระบบจะสร้างข้อความแจ้งเตือนในแชทระหว่างผู้ซื้อและผู้ขายทันทีเมื่อยืนยันวันส่งมอบ
+                </div>
+                <Link href="/buy/send-documents" className="text-xs text-blue-700 underline">
+                  ดูตัวอย่างข้อความในแชท
+                </Link>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="inspection" className="space-y-6">
+            <Card className="border-none shadow-sm">
+              <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <CardTitle className="flex items-center gap-2 text-xl font-semibold text-gray-900">
+                    <ClipboardList className="h-5 w-5 text-emerald-500" />
+                    รายการตรวจเช็คสภาพบ้าน
+                  </CardTitle>
+                  <CardDescription className="text-sm text-gray-600">
+                    ผู้ซื้อและผู้ขายสามารถเพิ่มรายการเพิ่มเติมได้ เพื่อให้ครอบคลุมรายละเอียดทุกจุด
+                  </CardDescription>
+                </div>
+                <Button onClick={handleOpenReport} variant="outline" className="border-rose-200 text-rose-600 hover:bg-rose-50">
+                  <AlertCircle className="mr-2 h-4 w-4" /> รายงานปัญหาอื่น ๆ
+                </Button>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="grid gap-4 rounded-2xl border border-dashed border-emerald-200 bg-emerald-50/60 p-4 sm:grid-cols-4">
+                  <div className="sm:col-span-2">
+                    <Label htmlFor="new-checklist-title" className="text-sm font-semibold text-gray-700">
+                      เพิ่มรายการตรวจเช็คใหม่
+                    </Label>
+                    <Input
+                      id="new-checklist-title"
+                      placeholder="หัวข้อรายการ เช่น ตรวจพื้นห้องนอน"
+                      value={newChecklistTitle}
+                      onChange={(event) => setNewChecklistTitle(event.target.value)}
+                    />
+                  </div>
+                  <div className="sm:col-span-1">
+                    <Label htmlFor="new-checklist-owner" className="text-sm font-semibold text-gray-700">
+                      ผู้เพิ่มรายการ
+                    </Label>
+                    <Select value={newChecklistOwner} onValueChange={(value: "buyer" | "seller") => setNewChecklistOwner(value)}>
+                      <SelectTrigger id="new-checklist-owner">
+                        <SelectValue placeholder="เลือกบทบาท" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="buyer">ผู้ซื้อ</SelectItem>
+                        <SelectItem value="seller">ผู้ขาย</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="sm:col-span-3">
+                    <Label htmlFor="new-checklist-description" className="text-sm font-semibold text-gray-700">
+                      รายละเอียดเพิ่มเติม (ถ้ามี)
+                    </Label>
+                    <Input
+                      id="new-checklist-description"
+                      placeholder="รายละเอียดเพิ่มเติมของจุดที่ต้องตรวจ"
+                      value={newChecklistDescription}
+                      onChange={(event) => setNewChecklistDescription(event.target.value)}
+                    />
+                  </div>
+                  <div className="flex items-end">
+                    <Button type="button" onClick={handleAddChecklistItem} className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
+                      <Plus className="mr-2 h-4 w-4" /> เพิ่มรายการ
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="grid gap-4">
+                  {checklistItems.map((item) => (
+                    <Card key={item.id} className="border border-slate-200">
+                      <CardContent className="flex flex-col gap-4 p-5 sm:flex-row sm:justify-between">
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-2">
+                            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600">
+                              {item.createdBy === "buyer" ? "ผู้ซื้อเพิ่ม" : "ผู้ขายเพิ่ม"}
+                            </span>
+                            <span
+                              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                                item.status === "pending"
+                                  ? "bg-slate-100 text-slate-600"
+                                  : item.status === "passed"
+                                  ? "bg-emerald-100 text-emerald-700"
+                                  : "bg-rose-100 text-rose-700"
+                              }`}
+                            >
+                              {item.status === "pending"
+                                ? "รอตรวจเช็ค"
+                                : item.status === "passed"
+                                ? "ผ่านการตรวจ"
+                                : "พบปัญหา"}
+                            </span>
+                          </div>
+                          <h3 className="text-lg font-semibold text-gray-900">{item.title}</h3>
+                          <p className="text-sm text-gray-600">
+                            {item.description || "ไม่มีรายละเอียดเพิ่มเติม"}
+                          </p>
+                          <p className="text-xs text-gray-400">
+                            อัปเดตล่าสุด {format(new Date(item.lastUpdatedAt), "d MMM yyyy HH:mm")}
+                          </p>
+                        </div>
+                        <div className="flex flex-col items-stretch gap-2 sm:w-52">
+                          <Button
+                            variant="outline"
+                            className="border-emerald-200 text-emerald-600 hover:bg-emerald-50"
+                            onClick={() => handleChecklistStatus(item.id, "passed")}
+                          >
+                            <Check className="mr-2 h-4 w-4" /> ผ่านการตรวจ
+                          </Button>
+                          <Button
+                            variant="outline"
+                            className="border-rose-200 text-rose-600 hover:bg-rose-50"
+                            onClick={() => handleChecklistStatus(item.id, "issue")}
+                          >
+                            <AlertCircle className="mr-2 h-4 w-4" /> พบปัญหา
+                          </Button>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="defects" className="space-y-6">
+            <Card className="border-none shadow-sm">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-xl font-semibold text-gray-900">
+                  <ShieldCheck className="h-5 w-5 text-purple-500" />
+                  Defect Tracking Progress
+                </CardTitle>
+                <CardDescription className="text-sm text-gray-600">
+                  ติดตามความคืบหน้าการแก้ไขปัญหาจากการตรวจรับบ้านแบบเรียลไทม์ พร้อมอัปเดตสถานะให้ผู้เกี่ยวข้องรับทราบ
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        Overall Progress
+                      </p>
+                      <p className="text-3xl font-bold text-gray-900">{overallProgress}%</p>
+                    </div>
+                    <div className="w-full sm:w-1/2">
+                      <div className="h-3 w-full rounded-full bg-white shadow-inner">
+                        <div
+                          className="h-3 rounded-full bg-purple-500"
+                          style={{ width: `${overallProgress}%` }}
+                        />
+                      </div>
+                      <p className="mt-2 text-xs text-gray-500">
+                        ปัญหาที่แก้ไขสำเร็จ {issueStatusCounts.completed} จาก {issues.length} รายการ
+                      </p>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 text-xs text-gray-600 sm:w-64">
+                      {Object.entries(issueStatusCounts).map(([status, count]) => (
+                        <div
+                          key={status}
+                          className="flex items-center gap-2 rounded-xl border border-white/60 bg-white px-3 py-2"
+                        >
+                          <span
+                            className={`h-2.5 w-2.5 rounded-full ${defectStatusMeta[status as DefectStatus].progressColor}`}
+                          />
+                          <span className="font-medium text-gray-900">
+                            {defectStatusMeta[status as DefectStatus].label}
+                          </span>
+                          <span>({count})</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid gap-5">
+                  {issues.map((issue) => (
+                    <Card key={issue.id} className="overflow-hidden border border-slate-200">
+                      <CardHeader className="flex flex-col gap-3 bg-slate-50/80 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <CardTitle className="text-lg font-semibold text-gray-900">{issue.title}</CardTitle>
+                          <CardDescription className="text-sm text-gray-600">{issue.description}</CardDescription>
+                        </div>
+                        <div className={`inline-flex items-center gap-2 rounded-full px-4 py-1 text-xs font-semibold ${defectStatusMeta[issue.status].badgeClass}`}>
+                          <Clock className="h-4 w-4" />
+                          {defectStatusMeta[issue.status].label}
+                        </div>
+                      </CardHeader>
+                      <CardContent className="grid gap-4 p-5 sm:grid-cols-3">
+                        <div className="space-y-2 text-sm text-gray-600">
+                          <p className="font-semibold text-gray-900">รายละเอียด</p>
+                          <p>ตำแหน่ง: {issue.location}</p>
+                          <p>ผู้แจ้ง: {issue.reportedBy === "buyer" ? "ผู้ซื้อ" : "ผู้ขาย"}</p>
+                          <p>วันที่แจ้ง: {format(new Date(issue.reportedAt), "d MMM yyyy")}</p>
+                          {issue.expectedCompletion && (
+                            <p>คาดว่าจะเสร็จ: {format(new Date(issue.expectedCompletion), "d MMM yyyy")}</p>
+                          )}
+                          {issue.resolvedAt && (
+                            <p className="text-emerald-600">ปิดงานแล้ว: {format(new Date(issue.resolvedAt), "d MMM yyyy")}</p>
+                          )}
+                        </div>
+                        <div className="space-y-2 text-sm text-gray-600">
+                          <p className="font-semibold text-gray-900">หลักฐานแนบ</p>
+                          <p>{issue.attachments ?? 0} ไฟล์ (รูป/วิดีโอ)</p>
+                          <Button variant="outline" size="sm" className="mt-2 w-fit border-slate-200 text-slate-600 hover:bg-slate-100">
+                            <ImagesIcon className="mr-2 h-4 w-4" /> ดูไฟล์แนบ
+                          </Button>
+                        </div>
+                        <div className="flex flex-col gap-2">
+                          <Label htmlFor={`status-${issue.id}`} className="text-sm font-semibold text-gray-900">
+                            อัปเดตสถานะโดยผู้ขาย
+                          </Label>
+                          <Select value={issue.status} onValueChange={(value: DefectStatus) => handleIssueStatusChange(issue.id, value)}>
+                            <SelectTrigger id={`status-${issue.id}`} className="border-purple-200">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="pending">รอดำเนินการ</SelectItem>
+                              <SelectItem value="in-progress">กำลังแก้ไข</SelectItem>
+                              <SelectItem value="verified">รอตรวจสอบ</SelectItem>
+                              <SelectItem value="completed">แก้ไขเสร็จ</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+
+                <Card className="border border-slate-200">
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-lg font-semibold text-gray-900">
+                      <CalendarIcon className="h-5 w-5 text-purple-500" />
+                      ปฏิทินการส่งมอบและแก้ไขปัญหา
+                    </CardTitle>
+                    <CardDescription className="text-sm text-gray-600">
+                      แสดงไทม์ไลน์ของวันส่งมอบ การแจ้งปัญหา และวันที่แก้ไขสำเร็จ เพื่อวางแผนงานให้เป็นระบบ
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {calendarEvents.length === 0 ? (
+                      <p className="text-sm text-gray-500">ยังไม่มีนัดหมายหรือการแจ้งปัญหาในระบบ</p>
+                    ) : (
+                      <div className="space-y-4">
+                        {calendarEvents.map((event) => (
+                          <div key={event.id} className="flex items-start gap-3">
+                            <div
+                              className={`mt-1 h-3 w-3 rounded-full ${
+                                event.type === "handover"
+                                  ? "bg-blue-500"
+                                  : event.type === "report"
+                                  ? "bg-amber-500"
+                                  : "bg-emerald-500"
+                              }`}
+                            />
+                            <div>
+                              <p className="text-sm font-semibold text-gray-900">{event.title}</p>
+                              <p className="text-xs text-gray-500">{format(new Date(event.date), "d MMM yyyy HH:mm")}</p>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-gray-900">
+              <AlertCircle className="h-5 w-5 text-rose-500" />
+              รายงานปัญหาที่พบระหว่างตรวจรับบ้าน
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="report-title" className="text-sm font-medium text-gray-700">
+                หัวข้อปัญหา
+              </Label>
+              <Input
+                id="report-title"
+                value={reportTitle}
+                onChange={(event) => setReportTitle(event.target.value)}
+                placeholder="เช่น ประตูห้องนอนปิดไม่สนิท"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="report-description" className="text-sm font-medium text-gray-700">
+                รายละเอียดเพิ่มเติม
+              </Label>
+              <Textarea
+                id="report-description"
+                value={reportDescription}
+                onChange={(event) => setReportDescription(event.target.value)}
+                rows={3}
+                placeholder="อธิบายลักษณะปัญหาเพื่อให้ทีมช่างเข้าใจตรงกัน"
+              />
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="report-location" className="text-sm font-medium text-gray-700">
+                  พื้นที่ที่พบปัญหา
+                </Label>
+                <Input
+                  id="report-location"
+                  value={reportLocation}
+                  onChange={(event) => setReportLocation(event.target.value)}
+                  placeholder="เช่น ห้องน้ำชั้น 2"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="report-expected" className="text-sm font-medium text-gray-700">
+                  คาดว่าจะเสร็จ (โดยประมาณ)
+                </Label>
+                <Input
+                  id="report-expected"
+                  type="date"
+                  value={reportExpectedDate}
+                  onChange={(event) => setReportExpectedDate(event.target.value)}
+                  min={new Date().toISOString().split("T")[0]}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="report-by" className="text-sm font-medium text-gray-700">
+                ผู้รายงาน
+              </Label>
+              <Select value={reportBy} onValueChange={(value: "buyer" | "seller") => setReportBy(value)}>
+                <SelectTrigger id="report-by">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="buyer">ผู้ซื้อ</SelectItem>
+                  <SelectItem value="seller">ผู้ขาย</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex justify-end gap-3 pt-2">
+              <Button variant="outline" onClick={() => setReportDialogOpen(false)}>
+                ยกเลิก
+              </Button>
+              <Button onClick={handleSubmitReport} className="bg-rose-600 text-white hover:bg-rose-700">
+                ส่งรายงานปัญหา
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/sell/home-inspection/page.tsx
+++ b/app/sell/home-inspection/page.tsx
@@ -1703,236 +1703,235 @@ export default function SellerHomeInspectionPage() {
           </TabsContent>
         </Tabs>
       </div>
+    </div>
 
-      <Dialog open={notificationsOpen} onOpenChange={setNotificationsOpen}>
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-              <Bell className="h-5 w-5 text-amber-500" />
-              การแจ้งเตือนทั้งหมด
-            </DialogTitle>
-          </DialogHeader>
-          <div className="max-h-[60vh] space-y-3 overflow-y-auto py-2">
-            {notificationsLoading ? (
-              <div className="flex items-center justify-center py-8 text-sm text-slate-500">
-                กำลังโหลดการแจ้งเตือน...
-              </div>
-            ) : notifications.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
-                ยังไม่มีการแจ้งเตือนจากระบบ
-              </div>
-            ) : (
-              notifications.map((notification) => {
-                const categoryMeta = notificationCategoryMeta[notification.category]
-                return (
-                  <div
-                    key={notification.id}
-                    className={`rounded-2xl border p-4 shadow-sm transition ${
-                      notification.read
-                        ? "border-slate-200 bg-white"
-                        : "border-amber-200 bg-amber-50/70"
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="space-y-2">
-                        <p className="text-sm font-semibold text-slate-900">{notification.title}</p>
-                        <p className="text-sm text-slate-600">{notification.message}</p>
-                        <p className="text-xs text-slate-400">
-                          {safeFormatDateTime(notification.createdAt)} • {" "}
-                          {notification.triggeredBy === "buyer" ? "ผู้ซื้อ" : "ผู้ขาย"}
-                        </p>
-                      </div>
-                      <Badge
-                        className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${categoryMeta.tone}`}
-                      >
-                        {categoryMeta.label}
-                      </Badge>
+    <Dialog open={notificationsOpen} onOpenChange={setNotificationsOpen}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <Bell className="h-5 w-5 text-amber-500" />
+            การแจ้งเตือนทั้งหมด
+          </DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[60vh] space-y-3 overflow-y-auto py-2">
+          {notificationsLoading ? (
+            <div className="flex items-center justify-center py-8 text-sm text-slate-500">
+              กำลังโหลดการแจ้งเตือน...
+            </div>
+          ) : notifications.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
+              ยังไม่มีการแจ้งเตือนจากระบบ
+            </div>
+          ) : (
+            notifications.map((notification) => {
+              const categoryMeta = notificationCategoryMeta[notification.category]
+              return (
+                <div
+                  key={notification.id}
+                  className={`rounded-2xl border p-4 shadow-sm transition ${
+                    notification.read
+                      ? "border-slate-200 bg-white"
+                      : "border-amber-200 bg-amber-50/70"
+                  }`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-2">
+                      <p className="text-sm font-semibold text-slate-900">{notification.title}</p>
+                      <p className="text-sm text-slate-600">{notification.message}</p>
+                      <p className="text-xs text-slate-400">
+                        {safeFormatDateTime(notification.createdAt)} • {" "}
+                        {notification.triggeredBy === "buyer" ? "ผู้ซื้อ" : "ผู้ขาย"}
+                      </p>
                     </div>
+                    <Badge
+                      className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${categoryMeta.tone}`}
+                    >
+                      {categoryMeta.label}
+                    </Badge>
                   </div>
-                )
-              })
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
 
-      <Dialog
-        open={Boolean(checklistItemToDelete)}
-        onOpenChange={(open) => {
-          if (!open) {
-            setChecklistItemToDelete(null)
-          }
-        }}
-      >
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-base font-semibold text-slate-900">
-              <Trash2 className="h-5 w-5 text-red-500" />
-              ลบรายการตรวจ
-            </DialogTitle>
-            <DialogDescription className="text-sm text-slate-600">
-              {checklistItemToDelete
-                ? `ต้องการลบ "${checklistItemToDelete.title}" ออกจากเช็คลิสต์หรือไม่?`
-                : "ต้องการลบรายการนี้ออกจากเช็คลิสต์หรือไม่"}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="flex justify-end gap-2">
+    <Dialog
+      open={Boolean(checklistItemToDelete)}
+      onOpenChange={(open) => {
+        if (!open) {
+          setChecklistItemToDelete(null)
+        }
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-base font-semibold text-slate-900">
+            <Trash2 className="h-5 w-5 text-red-500" />
+            ลบรายการตรวจ
+          </DialogTitle>
+          <DialogDescription className="text-sm text-slate-600">
+            {checklistItemToDelete
+              ? `ต้องการลบ "${checklistItemToDelete.title}" ออกจากเช็คลิสต์หรือไม่?`
+              : "ต้องการลบรายการนี้ออกจากเช็คลิสต์หรือไม่"}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setChecklistItemToDelete(null)}
+            className="border-slate-200 text-slate-600 hover:bg-slate-100"
+            disabled={deletingChecklist}
+          >
+            ยกเลิก
+          </Button>
+          <Button
+            onClick={handleConfirmDeleteChecklist}
+            disabled={deletingChecklist}
+            className="bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+          >
+            ลบรายการ
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+
+    <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
+      <DialogContent className="w-[min(95vw,38rem)] max-h-[calc(100vh-4rem)] overflow-y-auto max-w-2xl sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <AlertCircle className="h-5 w-5 text-purple-600" />
+            สร้างรายการ Defect ใหม่
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="defect-title" className="text-xs font-semibold text-slate-700">
+              หัวข้อปัญหา
+            </Label>
+            <Input
+              id="defect-title"
+              value={reportTitle}
+              onChange={(event) => setReportTitle(event.target.value)}
+              placeholder="เช่น เก็บซิลิโคนรอบอ่างใหม่"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="defect-location" className="text-xs font-semibold text-slate-700">
+              ตำแหน่งที่พบ
+            </Label>
+            <Input
+              id="defect-location"
+              value={reportLocation}
+              onChange={(event) => setReportLocation(event.target.value)}
+              placeholder="เช่น ห้องน้ำชั้น 2"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="defect-description" className="text-xs font-semibold text-slate-700">
+              รายละเอียดเพิ่มเติม (ไม่บังคับ)
+            </Label>
+            <Textarea
+              id="defect-description"
+              value={reportDescription}
+              onChange={(event) => setReportDescription(event.target.value)}
+              placeholder="บรรยายสิ่งที่ต้องแก้ไขหรือวัสดุที่ต้องใช้"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label className="text-xs font-semibold text-slate-700">
+              แนบรูปก่อนแก้ไข (ไม่บังคับ)
+            </Label>
+            <div className="space-y-3 rounded-2xl border border-dashed border-slate-200 p-4">
+              <div className="flex items-center gap-2 text-xs text-slate-500">
+                <Upload className="h-4 w-4 text-slate-400" /> เพิ่มรูปเพื่อให้ทีมเห็นปัญหาเดิม
+              </div>
+              <Input
+                ref={reportBeforeInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handleReportBeforePhotoChange}
+                disabled={creatingIssue}
+              />
+              {reportBeforePhotos.length === 0 ? (
+                <p className="text-xs text-slate-500">
+                  เลือกรูปสภาพก่อนแก้ไขเพื่อใช้เปรียบเทียบกับงานที่ปรับแล้ว
+                </p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {reportBeforePhotos.map((entry) => (
+                    <div
+                      key={entry.preview}
+                      className="relative h-20 w-28 overflow-hidden rounded-lg border border-slate-200"
+                    >
+                      <img
+                        src={entry.preview}
+                        alt="ก่อนแก้ไข"
+                        className="h-full w-full object-cover"
+                      />
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="absolute right-1 top-1 h-6 w-6 rounded-full bg-white/80 text-red-500 hover:bg-white"
+                        onClick={() => handleRemoveBeforePhoto(entry.preview)}
+                        disabled={creatingIssue}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        <span className="sr-only">ลบรูปนี้</span>
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="defect-date" className="text-xs font-semibold text-slate-700">
+                กำหนดเสร็จ (ไม่บังคับ)
+              </Label>
+              <Input
+                id="defect-date"
+                type="date"
+                value={reportExpectedDate}
+                onChange={(event) => setReportExpectedDate(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="defect-owner" className="text-xs font-semibold text-slate-700">
+                ผู้รับผิดชอบ (ไม่บังคับ)
+              </Label>
+              <Input
+                id="defect-owner"
+                value={reportOwner}
+                onChange={(event) => setReportOwner(event.target.value)}
+                placeholder="เช่น ทีมช่างคุณเอ็ม"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
             <Button
               variant="outline"
-              onClick={() => setChecklistItemToDelete(null)}
-              className="border-slate-200 text-slate-600 hover:bg-slate-100"
-              disabled={deletingChecklist}
+              onClick={() => setReportDialogOpen(false)}
+              className="border-slate-200 text-slate-700 hover:bg-slate-100"
+              disabled={creatingIssue}
             >
               ยกเลิก
             </Button>
             <Button
-              onClick={handleConfirmDeleteChecklist}
-              disabled={deletingChecklist}
-              className="bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+              onClick={handleCreateIssue}
+              disabled={creatingIssue}
+              className="bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-60"
             >
-              ลบรายการ
+              บันทึกรายการ
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
-        <DialogContent className="w-[min(95vw,38rem)] max-h-[calc(100vh-4rem)] overflow-y-auto max-w-2xl sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-              <AlertCircle className="h-5 w-5 text-purple-600" />
-              สร้างรายการ Defect ใหม่
-            </DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
-            <div className="space-y-2">
-              <Label htmlFor="defect-title" className="text-xs font-semibold text-slate-700">
-                หัวข้อปัญหา
-              </Label>
-              <Input
-                id="defect-title"
-                value={reportTitle}
-                onChange={(event) => setReportTitle(event.target.value)}
-                placeholder="เช่น เก็บซิลิโคนรอบอ่างใหม่"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="defect-location" className="text-xs font-semibold text-slate-700">
-                ตำแหน่งที่พบ
-              </Label>
-              <Input
-                id="defect-location"
-                value={reportLocation}
-                onChange={(event) => setReportLocation(event.target.value)}
-                placeholder="เช่น ห้องน้ำชั้น 2"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="defect-description" className="text-xs font-semibold text-slate-700">
-                รายละเอียดเพิ่มเติม (ไม่บังคับ)
-              </Label>
-              <Textarea
-                id="defect-description"
-                value={reportDescription}
-                onChange={(event) => setReportDescription(event.target.value)}
-                placeholder="บรรยายสิ่งที่ต้องแก้ไขหรือวัสดุที่ต้องใช้"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label className="text-xs font-semibold text-slate-700">
-                แนบรูปก่อนแก้ไข (ไม่บังคับ)
-              </Label>
-              <div className="space-y-3 rounded-2xl border border-dashed border-slate-200 p-4">
-                <div className="flex items-center gap-2 text-xs text-slate-500">
-                  <Upload className="h-4 w-4 text-slate-400" /> เพิ่มรูปเพื่อให้ทีมเห็นปัญหาเดิม
-                </div>
-                <Input
-                  ref={reportBeforeInputRef}
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  onChange={handleReportBeforePhotoChange}
-                  disabled={creatingIssue}
-                />
-                {reportBeforePhotos.length === 0 ? (
-                  <p className="text-xs text-slate-500">
-                    เลือกรูปสภาพก่อนแก้ไขเพื่อใช้เปรียบเทียบกับงานที่ปรับแล้ว
-                  </p>
-                ) : (
-                  <div className="flex flex-wrap gap-2">
-                    {reportBeforePhotos.map((entry) => (
-                      <div
-                        key={entry.preview}
-                        className="relative h-20 w-28 overflow-hidden rounded-lg border border-slate-200"
-                      >
-                        <img
-                          src={entry.preview}
-                          alt="ก่อนแก้ไข"
-                          className="h-full w-full object-cover"
-                        />
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="ghost"
-                          className="absolute right-1 top-1 h-6 w-6 rounded-full bg-white/80 text-red-500 hover:bg-white"
-                          onClick={() => handleRemoveBeforePhoto(entry.preview)}
-                          disabled={creatingIssue}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                          <span className="sr-only">ลบรูปนี้</span>
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-2">
-                <Label htmlFor="defect-date" className="text-xs font-semibold text-slate-700">
-                  กำหนดเสร็จ (ไม่บังคับ)
-                </Label>
-                <Input
-                  id="defect-date"
-                  type="date"
-                  value={reportExpectedDate}
-                  onChange={(event) => setReportExpectedDate(event.target.value)}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="defect-owner" className="text-xs font-semibold text-slate-700">
-                  ผู้รับผิดชอบ (ไม่บังคับ)
-                </Label>
-                <Input
-                  id="defect-owner"
-                  value={reportOwner}
-                  onChange={(event) => setReportOwner(event.target.value)}
-                  placeholder="เช่น ทีมช่างคุณเอ็ม"
-                />
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 pt-2">
-              <Button
-                variant="outline"
-                onClick={() => setReportDialogOpen(false)}
-                className="border-slate-200 text-slate-700 hover:bg-slate-100"
-                disabled={creatingIssue}
-              >
-                ยกเลิก
-              </Button>
-              <Button
-                onClick={handleCreateIssue}
-                disabled={creatingIssue}
-                className="bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-60"
-              >
-                บันทึกรายการ
-              </Button>
-            </div>
           </div>
-        </DialogContent>
-      </Dialog>
         </div>
-      </div>
+      </DialogContent>
+    </Dialog>
     </>
   )
 }

--- a/app/sell/home-inspection/page.tsx
+++ b/app/sell/home-inspection/page.tsx
@@ -1681,7 +1681,7 @@ export default function SellerHomeInspectionPage() {
       </Dialog>
 
       <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="w-[min(95vw,38rem)] max-w-2xl sm:max-w-xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
               <AlertCircle className="h-5 w-5 text-purple-600" />

--- a/app/sell/home-inspection/page.tsx
+++ b/app/sell/home-inspection/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { format, parseISO } from "date-fns"
 import {
   AlertCircle,
+  Bell,
   Calendar as CalendarIcon,
   ClipboardCheck,
   ClipboardList,
@@ -38,9 +39,11 @@ import { subscribeToDocument } from "@/lib/firestore"
 import {
   createInspectionChecklistItem,
   createInspectionIssue,
+  markInspectionNotificationsRead,
   subscribeToInspectionChecklist,
   subscribeToInspectionIssues,
   subscribeToInspectionState,
+  subscribeToInspectionNotifications,
   updateInspectionChecklistItem,
   updateInspectionIssue,
   updateInspectionState,
@@ -50,9 +53,11 @@ import type {
   HomeInspectionChecklistItem,
   HomeInspectionIssue,
   HomeInspectionIssueStatus,
+  HomeInspectionNotification,
   HomeInspectionState,
   SellerChecklistStatus,
 } from "@/types/home-inspection"
+import type { ChatOpenEventDetail } from "@/types/chat"
 import type { UserProperty } from "@/types/user-property"
 
 const sellerStatusMeta: Record<
@@ -100,6 +105,32 @@ const issueStatusOptions: { value: HomeInspectionIssueStatus; label: string }[] 
   { value: "buyer-review", label: "ส่งให้ผู้ซื้อเช็ก" },
   { value: "completed", label: "ปิดงานเรียบร้อย" },
 ]
+
+const notificationCategoryMeta: Record<
+  HomeInspectionNotification["category"],
+  { label: string; tone: string }
+> = {
+  general: {
+    label: "ทั่วไป",
+    tone: "bg-slate-100 text-slate-700 border-slate-200",
+  },
+  schedule: {
+    label: "นัดหมาย",
+    tone: "bg-indigo-100 text-indigo-700 border-indigo-200",
+  },
+  checklist: {
+    label: "เช็คลิสต์",
+    tone: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  },
+  issue: {
+    label: "แจ้งซ่อม",
+    tone: "bg-purple-100 text-purple-700 border-purple-200",
+  },
+  note: {
+    label: "บันทึก",
+    tone: "bg-amber-100 text-amber-700 border-amber-200",
+  },
+}
 
 const safeFormatDate = (value: string) => {
   try {
@@ -161,6 +192,10 @@ export default function SellerHomeInspectionPage() {
   const [creatingIssue, setCreatingIssue] = useState(false)
 
   const [updatingIssues, setUpdatingIssues] = useState<Record<string, boolean>>({})
+
+  const [notifications, setNotifications] = useState<HomeInspectionNotification[]>([])
+  const [notificationsLoading, setNotificationsLoading] = useState(true)
+  const [notificationsOpen, setNotificationsOpen] = useState(false)
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -317,6 +352,43 @@ export default function SellerHomeInspectionPage() {
   }, [propertyId, toast])
 
   useEffect(() => {
+    if (!propertyId) {
+      setNotifications([])
+      setNotificationsLoading(false)
+      return
+    }
+
+    let active = true
+    let unsubscribe: (() => void) | undefined
+    setNotificationsLoading(true)
+
+    void (async () => {
+      try {
+        unsubscribe = await subscribeToInspectionNotifications(propertyId, "seller", (items) => {
+          if (!active) return
+          setNotifications(items)
+          setNotificationsLoading(false)
+        })
+      } catch (error) {
+        console.error("Failed to subscribe notifications", error)
+        if (!active) return
+        setNotifications([])
+        setNotificationsLoading(false)
+        toast({
+          variant: "destructive",
+          title: "โหลดการแจ้งเตือนไม่สำเร็จ",
+          description: "ลองรีเฟรชหน้าหรือเชื่อมต่อใหม่อีกครั้ง",
+        })
+      }
+    })()
+
+    return () => {
+      active = false
+      unsubscribe?.()
+    }
+  }, [propertyId, toast])
+
+  useEffect(() => {
     if (stateLoading) return
     setHandoverDateInput(
       inspectionState.handoverDate ? inspectionState.handoverDate.slice(0, 10) : "",
@@ -412,6 +484,19 @@ export default function SellerHomeInspectionPage() {
       .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
   }, [inspectionState.handoverDate, issues, scheduleLabel])
 
+  const unreadNotifications = useMemo(
+    () => notifications.filter((notification) => !notification.read),
+    [notifications],
+  )
+
+  useEffect(() => {
+    if (!notificationsOpen || !propertyId) return
+    const unreadIds = unreadNotifications.map((item) => item.id)
+    if (unreadIds.length === 0) return
+
+    void markInspectionNotificationsRead(propertyId, unreadIds, "seller")
+  }, [notificationsOpen, propertyId, unreadNotifications])
+
   const handleSaveSchedule = async () => {
     if (!propertyId) return
     if (!handoverDateInput) {
@@ -445,6 +530,29 @@ export default function SellerHomeInspectionPage() {
     } finally {
       setSavingSchedule(false)
     }
+  }
+
+  const handleOpenChatPanel = () => {
+    if (typeof window === "undefined") return
+
+    const detail: ChatOpenEventDetail = property
+      ? {
+          participantId: property.confirmedBuyerId || undefined,
+          propertyPreview: {
+            propertyId: property.id,
+            ownerUid: property.userUid,
+            title: property.title,
+            price: property.price,
+            transactionType: property.transactionType,
+            thumbnailUrl: property.photos?.[0] ?? undefined,
+            address: property.address || undefined,
+            city: property.city || undefined,
+            province: property.province || undefined,
+          },
+        }
+      : {}
+
+    window.dispatchEvent(new CustomEvent<ChatOpenEventDetail>("dreamhome:open-chat", { detail }))
   }
 
   const handleAddChecklistItem = async () => {
@@ -489,7 +597,13 @@ export default function SellerHomeInspectionPage() {
   const handleSellerStatusChange = async (id: string, status: SellerChecklistStatus) => {
     if (!propertyId) return
     try {
-      await updateInspectionChecklistItem(propertyId, id, { sellerStatus: status })
+      const item = checklistItems.find((entry) => entry.id === id)
+      await updateInspectionChecklistItem(
+        propertyId,
+        id,
+        { sellerStatus: status },
+        { updatedBy: "seller", itemTitle: item?.title },
+      )
     } catch (error) {
       console.error("Failed to update seller status", error)
       toast({
@@ -504,10 +618,12 @@ export default function SellerHomeInspectionPage() {
     if (!propertyId) return
     setUpdatingIssues((prev) => ({ ...prev, [id]: true }))
     try {
+      const issue = issues.find((entry) => entry.id === id)
       await updateInspectionIssue(propertyId, id, {
         status,
         resolvedAt: status === "completed" ? new Date().toISOString() : null,
-      })
+      },
+      { updatedBy: "seller", issueTitle: issue?.title })
     } catch (error) {
       console.error("Failed to update issue status", error)
       toast({
@@ -528,9 +644,11 @@ export default function SellerHomeInspectionPage() {
     if (!propertyId) return
     setUpdatingIssues((prev) => ({ ...prev, [id]: true }))
     try {
+      const issue = issues.find((entry) => entry.id === id)
       await updateInspectionIssue(propertyId, id, {
         expectedCompletion: value ? `${value}T09:00:00` : null,
-      })
+      },
+      { updatedBy: "seller", issueTitle: issue?.title })
     } catch (error) {
       console.error("Failed to update issue due date", error)
       toast({
@@ -551,9 +669,11 @@ export default function SellerHomeInspectionPage() {
     if (!propertyId) return
     setUpdatingIssues((prev) => ({ ...prev, [id]: true }))
     try {
+      const issue = issues.find((entry) => entry.id === id)
       await updateInspectionIssue(propertyId, id, {
         owner: value.trim() || null,
-      })
+      },
+      { updatedBy: "seller", issueTitle: issue?.title })
     } catch (error) {
       console.error("Failed to update issue owner", error)
       toast({
@@ -693,6 +813,28 @@ export default function SellerHomeInspectionPage() {
               <div className="inline-flex items-center gap-2 rounded-xl bg-slate-100 px-4 py-2 text-xs font-medium text-slate-600">
                 <Home className="h-4 w-4 text-indigo-500" />
                 {property.title}
+              </div>
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                <Button
+                  onClick={handleOpenChatPanel}
+                  variant="outline"
+                  className="flex items-center gap-2 rounded-full border-indigo-200 text-indigo-700 hover:bg-indigo-50"
+                >
+                  <MessageCircle className="h-4 w-4" /> เปิดข้อความ
+                </Button>
+                <Button
+                  onClick={() => setNotificationsOpen(true)}
+                  variant="outline"
+                  disabled={notificationsLoading && notifications.length === 0}
+                  className="relative flex items-center gap-2 rounded-full border-amber-200 text-amber-700 hover:bg-amber-50"
+                >
+                  <Bell className="h-4 w-4" /> การแจ้งเตือน
+                  {unreadNotifications.length > 0 && (
+                    <span className="absolute -right-2 -top-1 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-amber-500 px-1 text-[10px] font-semibold text-white">
+                      {unreadNotifications.length > 99 ? "99+" : unreadNotifications.length}
+                    </span>
+                  )}
+                </Button>
               </div>
             </div>
             <Card className="w-full max-w-sm border border-slate-200 bg-slate-900 text-slate-50 shadow-lg">
@@ -1093,6 +1235,58 @@ export default function SellerHomeInspectionPage() {
           </TabsContent>
         </Tabs>
       </div>
+
+      <Dialog open={notificationsOpen} onOpenChange={setNotificationsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+              <Bell className="h-5 w-5 text-amber-500" />
+              การแจ้งเตือนทั้งหมด
+            </DialogTitle>
+          </DialogHeader>
+          <div className="max-h-[60vh] space-y-3 overflow-y-auto py-2">
+            {notificationsLoading ? (
+              <div className="flex items-center justify-center py-8 text-sm text-slate-500">
+                กำลังโหลดการแจ้งเตือน...
+              </div>
+            ) : notifications.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-slate-200 py-12 text-center text-sm text-slate-500">
+                ยังไม่มีการแจ้งเตือนจากระบบ
+              </div>
+            ) : (
+              notifications.map((notification) => {
+                const categoryMeta = notificationCategoryMeta[notification.category]
+                return (
+                  <div
+                    key={notification.id}
+                    className={`rounded-2xl border p-4 shadow-sm transition ${
+                      notification.read
+                        ? "border-slate-200 bg-white"
+                        : "border-amber-200 bg-amber-50/70"
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="space-y-2">
+                        <p className="text-sm font-semibold text-slate-900">{notification.title}</p>
+                        <p className="text-sm text-slate-600">{notification.message}</p>
+                        <p className="text-xs text-slate-400">
+                          {safeFormatDateTime(notification.createdAt)} • {" "}
+                          {notification.triggeredBy === "buyer" ? "ผู้ซื้อ" : "ผู้ขาย"}
+                        </p>
+                      </div>
+                      <Badge
+                        className={`rounded-full border px-3 py-1 text-[10px] font-semibold ${categoryMeta.tone}`}
+                      >
+                        {categoryMeta.label}
+                      </Badge>
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
         <DialogContent className="max-w-lg">

--- a/app/sell/home-inspection/page.tsx
+++ b/app/sell/home-inspection/page.tsx
@@ -54,6 +54,7 @@ import type {
   HomeInspectionIssue,
   HomeInspectionIssueStatus,
   HomeInspectionNotification,
+  HomeInspectionNotificationCountDetail,
   HomeInspectionState,
   SellerChecklistStatus,
 } from "@/types/home-inspection"
@@ -196,6 +197,19 @@ export default function SellerHomeInspectionPage() {
   const [notifications, setNotifications] = useState<HomeInspectionNotification[]>([])
   const [notificationsLoading, setNotificationsLoading] = useState(true)
   const [notificationsOpen, setNotificationsOpen] = useState(false)
+
+  useEffect(() => {
+    const handleOpenNotifications = () => setNotificationsOpen(true)
+
+    window.addEventListener("dreamhome:open-inspection-notifications", handleOpenNotifications)
+
+    return () => {
+      window.removeEventListener(
+        "dreamhome:open-inspection-notifications",
+        handleOpenNotifications,
+      )
+    }
+  }, [])
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -488,6 +502,35 @@ export default function SellerHomeInspectionPage() {
     () => notifications.filter((notification) => !notification.read),
     [notifications],
   )
+  const unreadNotificationCount = unreadNotifications.length
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    window.dispatchEvent(
+      new CustomEvent<HomeInspectionNotificationCountDetail>(
+        "dreamhome:inspection-notification-count",
+        {
+          detail: { count: unreadNotificationCount },
+        },
+      ),
+    )
+  }, [unreadNotificationCount])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    return () => {
+      window.dispatchEvent(
+        new CustomEvent<HomeInspectionNotificationCountDetail>(
+          "dreamhome:inspection-notification-count",
+          {
+            detail: { count: 0 },
+          },
+        ),
+      )
+    }
+  }, [])
 
   useEffect(() => {
     if (!notificationsOpen || !propertyId) return

--- a/app/sell/send-documents/page.tsx
+++ b/app/sell/send-documents/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
+import Link from "next/link"
 import { CheckCircle2, ClipboardList, FileText, NotebookPen } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -204,6 +205,23 @@ export default function SellerSendDocumentsPage() {
     }
   }
 
+  const handleGoToHandover = () => {
+    if (!remoteConfirmed) {
+      toast({
+        variant: "destructive",
+        title: "กรุณายืนยันการตรวจสอบเอกสารก่อน",
+        description: "กรุณาตรวจสอบและยืนยันเอกสารบังคับให้ครบ เพื่อปลดล็อกขั้นตอนกำหนดวันส่งมอบบ้าน",
+      })
+      return
+    }
+
+    const targetPath = propertyId
+      ? `/sell/home-inspection?propertyId=${propertyId}`
+      : "/sell/home-inspection"
+
+    router.push(targetPath)
+  }
+
   useEffect(() => {
     if (!loading && !user) {
       router.replace("/")
@@ -346,6 +364,22 @@ export default function SellerSendDocumentsPage() {
             >
               {remoteConfirmed ? "ยืนยันแล้ว" : "ยืนยันการตรวจสอบเอกสาร"}
             </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleGoToHandover}
+              className="border-violet-200 text-violet-700 hover:bg-violet-50"
+            >
+              ไปขั้นตอนนัดหมายส่งมอบบ้าน
+            </Button>
+            {remoteConfirmed && propertyId && (
+              <Link
+                href={`/sell/home-inspection?propertyId=${propertyId}`}
+                className="text-xs text-violet-600 underline"
+              >
+                แชร์ลิงก์ให้ผู้ซื้อร่วมตรวจบ้าน
+              </Link>
+            )}
           </div>
         </div>
       </div>

--- a/app/sell/send-documents/page.tsx
+++ b/app/sell/send-documents/page.tsx
@@ -363,7 +363,7 @@ export default function SellerSendDocumentsPage() {
                   type="button"
                   variant="outline"
                   onClick={() => setCancelDialogOpen(true)}
-                  className="inline-flex items-center gap-2 rounded-full border-red-200 text-xs font-semibold text-red-600 hover:bg-red-50"
+                  className="mt-4 inline-flex items-center gap-2 rounded-xl border-red-200 px-4 py-2 text-xs font-semibold text-red-600 hover:bg-red-50"
                 >
                   ยกเลิกรายการซื้อ
                 </Button>

--- a/components/buyer-confirmation-prompt.tsx
+++ b/components/buyer-confirmation-prompt.tsx
@@ -1,0 +1,328 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { useAuthContext } from "@/contexts/AuthContext"
+import { useToast } from "@/hooks/use-toast"
+import type { PropertyPreviewOpenEventDetail, PropertyPreviewPayload } from "@/types/chat"
+import { formatPropertyPrice } from "@/lib/property"
+import { subscribeToCollection, getDocument, updateDocument } from "@/lib/firestore"
+import { saveBuyerPropertyFromListing } from "@/lib/buyer-properties"
+import type { PropertyPurchaseStatus } from "@/types/property-purchase-status"
+import { buildPreviewFromPropertyRecord } from "@/lib/property-preview"
+
+interface BuyerConfirmationPromptProps {
+  isChatOpen: boolean
+}
+
+export const BuyerConfirmationPrompt: React.FC<BuyerConfirmationPromptProps> = ({
+  isChatOpen,
+}) => {
+  const { user } = useAuthContext()
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const [propertyStatusMap, setPropertyStatusMap] = useState<
+    Record<string, PropertyPurchaseStatus>
+  >({})
+  const [propertyPreviewMap, setPropertyPreviewMap] = useState<
+    Record<string, PropertyPreviewPayload>
+  >({})
+  const [activePropertyId, setActivePropertyId] = useState<string | null>(null)
+  const [confirmingPropertyId, setConfirmingPropertyId] = useState<string | null>(null)
+  const dismissedRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setPropertyStatusMap({})
+      setPropertyPreviewMap({})
+      setActivePropertyId(null)
+      dismissedRef.current.clear()
+      return undefined
+    }
+
+    let unsubscribe: (() => void) | undefined
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const { where } = await import("firebase/firestore")
+        unsubscribe = await subscribeToCollection(
+          "property",
+          (docs) => {
+            if (cancelled) return
+
+            const nextStatus: Record<string, PropertyPurchaseStatus> = {}
+            const nextPreview: Record<string, PropertyPreviewPayload> = {}
+
+            docs.forEach((doc) => {
+              const propertyId = doc.id
+              const data = doc.data() as Record<string, unknown>
+
+              const isUnderPurchase = Boolean(data.isUnderPurchase)
+              const buyerConfirmed = Boolean(data.buyerConfirmed)
+              const sellerDocumentsConfirmed = Boolean(data.sellerDocumentsConfirmed)
+              const confirmedBuyerId =
+                typeof data.confirmedBuyerId === "string" && data.confirmedBuyerId.trim().length > 0
+                  ? data.confirmedBuyerId.trim()
+                  : null
+
+              if (
+                isUnderPurchase &&
+                !buyerConfirmed &&
+                confirmedBuyerId === user.uid
+              ) {
+                nextStatus[propertyId] = {
+                  isUnderPurchase,
+                  confirmedBuyerId,
+                  buyerConfirmed,
+                  sellerDocumentsConfirmed,
+                }
+
+                const preview = buildPreviewFromPropertyRecord(propertyId, data)
+                if (preview) {
+                  nextPreview[propertyId] = preview
+                }
+              } else {
+                dismissedRef.current.delete(propertyId)
+              }
+            })
+
+            setPropertyStatusMap((previous) => {
+              for (const key of Object.keys(previous)) {
+                if (!nextStatus[key]) {
+                  dismissedRef.current.delete(key)
+                }
+              }
+              return nextStatus
+            })
+            setPropertyPreviewMap(nextPreview)
+          },
+          where("confirmedBuyerId", "==", user.uid),
+        )
+      } catch (error) {
+        console.error("Failed to subscribe buyer confirmation prompt", error)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      unsubscribe?.()
+    }
+  }, [user?.uid])
+
+  const eligiblePropertyId = useMemo(() => {
+    if (!user?.uid || isChatOpen) {
+      return null
+    }
+
+    return (
+      Object.entries(propertyStatusMap).find(([propertyId, status]) => {
+        if (!status?.isUnderPurchase) return false
+        if (status.buyerConfirmed) return false
+        if (dismissedRef.current.has(propertyId)) return false
+        return Boolean(propertyPreviewMap[propertyId])
+      })?.[0] ?? null
+    )
+  }, [isChatOpen, propertyPreviewMap, propertyStatusMap, user?.uid])
+
+  useEffect(() => {
+    if (eligiblePropertyId && eligiblePropertyId !== activePropertyId) {
+      setActivePropertyId(eligiblePropertyId)
+    } else if (!eligiblePropertyId) {
+      setActivePropertyId(null)
+    }
+  }, [activePropertyId, eligiblePropertyId])
+
+  const activePreview = activePropertyId ? propertyPreviewMap[activePropertyId] : null
+  const activeStatus = activePropertyId ? propertyStatusMap[activePropertyId] : null
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) return
+
+      const propertyId = activePropertyId
+      if (!propertyId) return
+
+      const status = propertyStatusMap[propertyId]
+      if (status?.isUnderPurchase && !status.buyerConfirmed) {
+        dismissedRef.current.add(propertyId)
+      } else {
+        dismissedRef.current.delete(propertyId)
+      }
+
+      setActivePropertyId(null)
+    },
+    [activePropertyId, propertyStatusMap],
+  )
+
+  const handleOpenPropertyPreview = useCallback(() => {
+    if (!activePreview?.propertyId) return
+    if (typeof window === "undefined") return
+
+    const detail: PropertyPreviewOpenEventDetail = {
+      propertyId: activePreview.propertyId,
+      ownerUid: activePreview.ownerUid,
+      preview: activePreview,
+    }
+
+    window.dispatchEvent(
+      new CustomEvent<PropertyPreviewOpenEventDetail>(
+        "dreamhome:open-property-preview",
+        {
+          detail,
+        },
+      ),
+    )
+  }, [activePreview])
+
+  const handleConfirm = useCallback(async () => {
+    if (!user?.uid || !activePreview?.propertyId || !activeStatus) {
+      return
+    }
+
+    if (!activeStatus.isUnderPurchase || activeStatus.confirmedBuyerId !== user.uid) {
+      toast({
+        variant: "destructive",
+        title: "ยืนยันไม่สำเร็จ",
+        description: "สถานะประกาศไม่ถูกต้องสำหรับการยืนยัน",
+      })
+      return
+    }
+
+    if (activeStatus.buyerConfirmed) {
+      router.push(`/buy/send-documents?propertyId=${activePreview.propertyId}`)
+      setActivePropertyId(null)
+      return
+    }
+
+    setConfirmingPropertyId(activePreview.propertyId)
+
+    try {
+      const confirmedAtIso = new Date().toISOString()
+      const propertyDoc = await getDocument("property", activePreview.propertyId)
+      const listingData = propertyDoc?.data() as Record<string, unknown> | null
+
+      const operations: Promise<void>[] = [
+        updateDocument("property", activePreview.propertyId, {
+          buyerConfirmed: true,
+          confirmedBuyerId: activeStatus.confirmedBuyerId ?? user.uid,
+        }),
+        saveBuyerPropertyFromListing({
+          buyerUid: user.uid,
+          propertyId: activePreview.propertyId,
+          listingData,
+          preview: activePreview,
+          confirmedAt: confirmedAtIso,
+        }),
+      ]
+
+      if (activePreview.ownerUid) {
+        operations.push(
+          updateDocument(`users/${activePreview.ownerUid}/user_property`, activePreview.propertyId, {
+            buyerConfirmed: true,
+          }),
+        )
+      }
+
+      await Promise.all(operations)
+
+      toast({
+        title: "ยืนยันการซื้อเรียบร้อย",
+        description: "ตรวจสอบรายการเอกสารที่ต้องเตรียมในขั้นตอนถัดไป",
+      })
+
+      dismissedRef.current.delete(activePreview.propertyId)
+      setActivePropertyId(null)
+      router.push(`/buy/send-documents?propertyId=${activePreview.propertyId}`)
+    } catch (error) {
+      console.error("Failed to auto-confirm buyer property", error)
+      toast({
+        variant: "destructive",
+        title: "ยืนยันไม่สำเร็จ",
+        description: error instanceof Error ? error.message : "กรุณาลองใหม่อีกครั้ง",
+      })
+    } finally {
+      setConfirmingPropertyId(null)
+    }
+  }, [activePreview, activeStatus, router, toast, user?.uid])
+
+  if (!activePreview || !activeStatus) {
+    return null
+  }
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg space-y-6 break-words text-pretty sm:max-w-xl md:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold sm:text-xl">
+            ผู้ขายยืนยันการซื้อแล้ว
+          </DialogTitle>
+          <DialogDescription className="break-words text-pretty text-sm sm:text-base">
+            {`ผู้ขายได้ยืนยันประกาศ ${activePreview.title}`}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 break-words rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 text-pretty text-sm text-amber-800 sm:text-base">
+          {activePreview.price && Number.isFinite(activePreview.price) && (
+            <p className="break-words font-semibold">
+              ราคา {formatPropertyPrice(activePreview.price, activePreview.transactionType ?? "sale")}
+            </p>
+          )}
+          {(activePreview.address || activePreview.city || activePreview.province) && (
+            <p className="break-words">
+              {[activePreview.address, activePreview.city, activePreview.province]
+                .filter((value): value is string => Boolean(value && value.trim()))
+                .join(" ")}
+            </p>
+          )}
+          <p className="break-words">
+            โปรดเตรียมเอกสารที่จำเป็นและติดตามการติดต่อจากผู้ขายเพื่อดำเนินการขั้นตอนถัดไป
+          </p>
+        </div>
+        <DialogFooter className="flex w-full flex-col gap-3 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            onClick={() => handleOpenChange(false)}
+            className="h-auto min-h-[3.25rem] w-full break-words whitespace-normal px-6 py-3 text-center text-base sm:w-auto sm:px-8 sm:text-lg"
+          >
+            ภายหลัง
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="lg"
+            onClick={handleOpenPropertyPreview}
+            className="h-auto min-h-[3.25rem] w-full break-words whitespace-normal px-6 py-3 text-center text-base sm:w-auto sm:px-8 sm:text-lg"
+          >
+            ดูรายละเอียดประกาศ
+          </Button>
+          <Button
+            type="button"
+            size="lg"
+            onClick={handleConfirm}
+            disabled={confirmingPropertyId === activePreview.propertyId}
+            className="h-auto min-h-[3.25rem] w-full break-words whitespace-normal px-6 py-3 text-center text-base sm:w-auto sm:px-8 sm:text-lg"
+          >
+            {confirmingPropertyId === activePreview.propertyId
+              ? "กำลังยืนยัน..."
+              : "ยืนยันเพื่อไปขั้นตอนถัดไป"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default BuyerConfirmationPrompt

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -1661,6 +1661,18 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
       return
     }
 
+    const hasExistingPreview = messages.some((message) => {
+      const previewId = message.propertyPreview?.propertyId
+      return previewId && queuedPropertyPreview.propertyId
+        ? previewId === queuedPropertyPreview.propertyId
+        : false
+    })
+
+    if (hasExistingPreview) {
+      setQueuedPropertyPreview(null)
+      return
+    }
+
     setSending(true)
 
     void (async () => {
@@ -1684,6 +1696,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
     })()
   }, [
     activeParticipantId,
+    messages,
     queuedPropertyPreview,
     sending,
     sendMessageToChat,

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -46,6 +46,7 @@ import type {
   PropertyPreviewOpenEventDetail,
   PropertyPreviewPayload,
 } from "@/types/chat"
+import type { PropertyPurchaseStatus } from "@/types/property-purchase-status"
 import {
   addDocument,
   getDocument,
@@ -59,6 +60,10 @@ import { cn } from "@/lib/utils"
 import { formatPropertyPrice, TRANSACTION_LABELS } from "@/lib/property"
 import { createUserNotification } from "@/lib/notifications"
 import { saveBuyerPropertyFromListing } from "@/lib/buyer-properties"
+import {
+  buildPreviewFromPropertyRecord,
+  sanitizePropertyPreview,
+} from "@/lib/property-preview"
 
 interface ChatPanelProps {
   isOpen: boolean
@@ -111,13 +116,6 @@ interface UserProfileSummary {
   email?: string
   photoURL?: string
   status?: UserPresenceSummary | null
-}
-
-interface PropertyPurchaseStatus {
-  isUnderPurchase: boolean
-  confirmedBuyerId: string | null
-  buyerConfirmed: boolean
-  sellerDocumentsConfirmed: boolean
 }
 
 const presenceDotClass = (isOnline: boolean) =>
@@ -246,98 +244,6 @@ interface SendMessageOptions {
   text?: string
   attachments?: ChatMessageAttachment[]
   propertyPreview?: PropertyPreviewPayload | null
-}
-
-const sanitizePropertyPreview = (preview: PropertyPreviewPayload) => {
-  return {
-    propertyId: preview.propertyId,
-    ownerUid: preview.ownerUid,
-    title: preview.title,
-    price: typeof preview.price === "number" ? preview.price : null,
-    transactionType:
-      typeof preview.transactionType === "string" ? preview.transactionType : null,
-    thumbnailUrl:
-      typeof preview.thumbnailUrl === "string" && preview.thumbnailUrl.trim().length > 0
-        ? preview.thumbnailUrl
-        : null,
-    address:
-      typeof preview.address === "string" && preview.address.trim().length > 0
-        ? preview.address
-        : null,
-    city:
-      typeof preview.city === "string" && preview.city.trim().length > 0
-        ? preview.city
-        : null,
-    province:
-      typeof preview.province === "string" && preview.province.trim().length > 0
-        ? preview.province
-        : null,
-  }
-}
-
-const buildPreviewFromPropertyRecord = (
-  propertyId: string,
-  record: Record<string, unknown>,
-): ChatMessagePropertyPreview | null => {
-  const ownerUid =
-    typeof record.userUid === "string" && record.userUid.trim().length > 0
-      ? record.userUid
-      : null
-
-  const title =
-    typeof record.title === "string" && record.title.trim().length > 0
-      ? record.title
-      : null
-
-  if (!ownerUid || !title) {
-    return null
-  }
-
-  let price: number | null = null
-  if (typeof record.price === "number" && Number.isFinite(record.price)) {
-    price = record.price
-  } else if (typeof record.price === "string") {
-    const parsed = Number(record.price)
-    price = Number.isFinite(parsed) ? parsed : null
-  }
-
-  const transactionType =
-    typeof record.transactionType === "string" && record.transactionType.trim().length > 0
-      ? record.transactionType
-      : null
-
-  const address =
-    typeof record.address === "string" && record.address.trim().length > 0
-      ? record.address
-      : null
-
-  const city =
-    typeof record.city === "string" && record.city.trim().length > 0 ? record.city : null
-
-  const province =
-    typeof record.province === "string" && record.province.trim().length > 0
-      ? record.province
-      : null
-
-  let thumbnailUrl: string | null = null
-  if (Array.isArray(record.photos)) {
-    const firstPhoto = record.photos.find(
-      (value): value is string => typeof value === "string" && value.trim().length > 0,
-    )
-    thumbnailUrl = firstPhoto ?? null
-  }
-
-  return sanitizePropertyPreview({
-    propertyId,
-    ownerUid,
-    title,
-    price,
-    transactionType,
-    thumbnailUrl,
-    address,
-    city,
-    province,
-  })
 }
 
 const formatPropertyPreviewSummary = (preview: PropertyPreviewPayload) => {
@@ -785,6 +691,22 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
             },
           ),
         ])
+
+        try {
+          await createUserNotification(activeParticipantId, {
+            title: "ผู้ขายยืนยันการซื้อแล้ว",
+            message: preview.title
+              ? `ประกาศ ${preview.title}`
+              : "ประกาศของคุณพร้อมสำหรับขั้นตอนถัดไป",
+            category: "system",
+            relatedId: preview.propertyId,
+            actionType: "navigate",
+            actionHref: `/buy/send-documents?propertyId=${preview.propertyId}`,
+            context: "ตรวจสอบเอกสารและยืนยันการรับบ้าน",
+          })
+        } catch (error) {
+          console.error("Failed to create buyer confirmation notification", error)
+        }
 
         toast({
           title: "ยืนยันประกาศสำเร็จ",

--- a/components/chat-panel.tsx
+++ b/components/chat-panel.tsx
@@ -56,6 +56,7 @@ import {
 import { getDownloadURL, uploadFile } from "@/lib/storage"
 import { cn } from "@/lib/utils"
 import { formatPropertyPrice, TRANSACTION_LABELS } from "@/lib/property"
+import { createUserNotification } from "@/lib/notifications"
 
 interface ChatPanelProps {
   isOpen: boolean
@@ -1632,6 +1633,34 @@ const ChatPanel: React.FC<ChatPanelProps> = ({
           updatedAt: serverTimestamp(),
         }),
       ])
+
+      try {
+        const senderEmail = user.email ?? ""
+        const senderName =
+          (user.displayName && user.displayName.trim().length > 0
+            ? user.displayName.trim()
+            : null) ||
+          (senderEmail && senderEmail.trim().length > 0
+            ? senderEmail.split("@")[0] ?? senderEmail
+            : null) ||
+          "ผู้ใช้ DreamHome"
+
+        const previewMessage =
+          messagePreview && messagePreview.trim().length > 0
+            ? messagePreview
+            : "ส่งข้อความใหม่"
+
+        await createUserNotification(targetUid, {
+          title: `ข้อความใหม่จาก ${senderName}`,
+          message: previewMessage,
+          category: "message",
+          relatedId: chatId,
+          actionType: "open-chat",
+          actionTarget: user.uid,
+        })
+      } catch (error) {
+        console.error("Failed to create chat notification", error)
+      }
     },
     [user?.uid],
   )

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/tooltip"
 import ProfileModal from "./profile-modal"
 import { UserPropertyModal } from "./user-property-modal"
+import BuyerConfirmationPrompt from "./buyer-confirmation-prompt"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -767,6 +768,7 @@ const Navigation: React.FC = () => {
           }
         }}
       />
+      <BuyerConfirmationPrompt isChatOpen={isChatOpen} />
     </>
   )
 }

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -279,6 +279,10 @@ const Navigation: React.FC = () => {
             : [],
         video: null,
         createdAt: new Date().toISOString(),
+        isUnderPurchase: false,
+        confirmedBuyerId: null,
+        buyerConfirmed: false,
+        sellerDocumentsConfirmed: false,
       }
     },
     [],

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -44,6 +44,7 @@ import {
   Bell,
   AlertCircle,
   Loader2,
+  KeyRound,
 } from "lucide-react"
 import SignInModal from "./sign-in-modal"
 import SignUpModal from "./sign-up-modal"
@@ -552,6 +553,12 @@ const Navigation: React.FC = () => {
                       <DropdownMenuItem onClick={() => setIsProfileOpen(true)}>
                         <User className="mr-2 h-4 w-4" />
                         <span>โปรไฟล์</span>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild>
+                        <Link href="/buy/my-properties" className="flex items-center">
+                          <KeyRound className="mr-2 h-4 w-4" />
+                          <span>อสังหาที่ซื้อของฉัน</span>
+                        </Link>
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={handleOpenNotifications}>
                         <Bell className="mr-2 h-4 w-4" />

--- a/components/sign-in-modal.tsx
+++ b/components/sign-in-modal.tsx
@@ -143,7 +143,7 @@ export default function SignInModal({ isOpen, onClose, onSwitchToSignUp }: SignI
 
     setIsSendingVerification(true)
     try {
-      await sendVerificationEmail(user)
+      await sendVerificationEmail()
       toast({
         title: "ส่งอีเมลยืนยันแล้ว",
         description: "กรุณาตรวจสอบอีเมลของคุณเพื่อยืนยันบัญชี",

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
 import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
@@ -94,11 +93,7 @@ const SheetContent = React.forwardRef<
         {...props}
       >
         {/* ถ้าไม่มี Title ให้เติม Title แบบซ่อนไว้เพื่อ a11y */}
-        {!hasTitle && (
-          <VisuallyHidden asChild>
-            <SheetTitle>{titleText}</SheetTitle>
-          </VisuallyHidden>
-        )}
+        {!hasTitle && <SheetTitle className="sr-only">{titleText}</SheetTitle>}
 
         {children}
 

--- a/components/user-property-modal.tsx
+++ b/components/user-property-modal.tsx
@@ -101,7 +101,7 @@ export function UserPropertyModal({
   const mediaItems = useMemo(() => {
     if (!property) return [];
 
-    const items = (property.photos ?? [])
+    const items: { id: string; type: "image" | "video"; url: string }[] = (property.photos ?? [])
       .filter(
         (photo): photo is string =>
           typeof photo === "string" && photo.trim().length > 0,

--- a/hooks/use-buyer-properties.ts
+++ b/hooks/use-buyer-properties.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { subscribeToCollection } from "@/lib/firestore";
+import {
+  mapDocumentToBuyerProperty,
+  parseBuyerPropertyConfirmedAt,
+} from "@/lib/buyer-property-mapper";
+import type { BuyerProperty } from "@/types/buyer-property";
+
+interface UseBuyerPropertiesResult {
+  properties: BuyerProperty[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useBuyerProperties(buyerUid: string | null): UseBuyerPropertiesResult {
+  const [properties, setProperties] = useState<BuyerProperty[]>([]);
+  const [loading, setLoading] = useState(Boolean(buyerUid));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+    let cancelled = false;
+
+    if (!buyerUid) {
+      setProperties([]);
+      setLoading(false);
+      setError(null);
+      return () => {};
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const load = async () => {
+      try {
+        unsubscribe = await subscribeToCollection(
+          `users/${buyerUid}/buyer_properties`,
+          (docs) => {
+            if (cancelled) return;
+            const mapped = docs.map(mapDocumentToBuyerProperty);
+            mapped.sort(
+              (a, b) =>
+                parseBuyerPropertyConfirmedAt(b.confirmedAt) -
+                parseBuyerPropertyConfirmedAt(a.confirmedAt),
+            );
+            setProperties(mapped);
+            setLoading(false);
+          },
+        );
+      } catch (err) {
+        console.error("Failed to load buyer properties", err);
+        if (cancelled) return;
+        setError("ไม่สามารถโหลดรายการทรัพย์ของผู้ซื้อได้");
+        setProperties([]);
+        setLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [buyerUid]);
+
+  return { properties, loading, error };
+}

--- a/hooks/use-notification-sound.ts
+++ b/hooks/use-notification-sound.ts
@@ -1,0 +1,55 @@
+"use client"
+
+import { useCallback, useRef } from "react"
+
+/**
+ * Simple notification tone shared across components to signal new alerts.
+ * Reuses a single AudioContext per hook instance to avoid repeated user prompts.
+ */
+export const useNotificationSound = () => {
+  const audioContextRef = useRef<AudioContext | null>(null)
+
+  const playNotificationSound = useCallback(async () => {
+    try {
+      if (typeof window === "undefined") return
+
+      const AudioContextConstructor =
+        window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+      if (!AudioContextConstructor) return
+
+      const audioContext = audioContextRef.current ?? new AudioContextConstructor()
+
+      if (audioContext.state === "suspended") {
+        await audioContext.resume()
+      }
+
+      const now = audioContext.currentTime
+      const oscillator = audioContext.createOscillator()
+      const gain = audioContext.createGain()
+
+      const peakGain = 0.7
+      const fadeOutTime = 0.6
+
+      oscillator.type = "sine"
+      oscillator.frequency.setValueAtTime(880, now)
+
+      gain.gain.setValueAtTime(0.0001, now)
+      gain.gain.exponentialRampToValueAtTime(peakGain, now + 0.05)
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + fadeOutTime)
+
+      oscillator.connect(gain)
+      gain.connect(audioContext.destination)
+
+      oscillator.start(now)
+      oscillator.stop(now + fadeOutTime)
+
+      audioContextRef.current = audioContext
+    } catch (error) {
+      console.error("Failed to play notification sound", error)
+    }
+  }, [])
+
+  return playNotificationSound
+}
+
+export default useNotificationSound

--- a/hooks/use-seller-handover-properties.ts
+++ b/hooks/use-seller-handover-properties.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { subscribeToCollection } from "@/lib/firestore";
+
+export interface SellerHandoverProperty {
+  id: string;
+  title: string;
+  handoverDate: string | null;
+  confirmedBuyerId: string | null;
+  isUnderPurchase: boolean;
+  address: string | null;
+  city: string | null;
+  province: string | null;
+}
+
+interface UseSellerHandoverPropertiesResult {
+  properties: SellerHandoverProperty[];
+  loading: boolean;
+}
+
+const toStringValue = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toString();
+  }
+  return "";
+};
+
+const toOptionalString = (value: unknown): string | null => {
+  const text = toStringValue(value).trim();
+  return text.length > 0 ? text : null;
+};
+
+const toIsoString = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (
+    value &&
+    typeof value === "object" &&
+    "toDate" in value &&
+    typeof (value as { toDate?: () => Date }).toDate === "function"
+  ) {
+    const date = (value as { toDate: () => Date }).toDate();
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return "";
+};
+
+export function useSellerHandoverProperties(
+  sellerUid: string | null,
+): UseSellerHandoverPropertiesResult {
+  const [properties, setProperties] = useState<SellerHandoverProperty[]>([]);
+  const [loading, setLoading] = useState(Boolean(sellerUid));
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | undefined;
+    let cancelled = false;
+
+    if (!sellerUid) {
+      setProperties([]);
+      setLoading(false);
+      return () => {};
+    }
+
+    setLoading(true);
+
+    const load = async () => {
+      try {
+        const { where } = await import("firebase/firestore");
+        unsubscribe = await subscribeToCollection(
+          "property",
+          (docs) => {
+            if (cancelled) return;
+            const mapped = docs.map((doc) => {
+              const data = doc.data() as Record<string, unknown>;
+              return {
+                id: doc.id,
+                title: toStringValue(data.title) || `ประกาศ ${doc.id}`,
+                handoverDate: (() => {
+                  const iso = toIsoString(data.handoverDate);
+                  return iso ? iso : null;
+                })(),
+                confirmedBuyerId: toOptionalString(data.confirmedBuyerId),
+                isUnderPurchase: Boolean(data.isUnderPurchase),
+                address: toOptionalString(data.address),
+                city: toOptionalString(data.city),
+                province: toOptionalString(data.province),
+              } satisfies SellerHandoverProperty;
+            });
+            setProperties(mapped);
+            setLoading(false);
+          },
+          where("userUid", "==", sellerUid),
+        );
+      } catch (error) {
+        console.error("Failed to load seller properties", error);
+        if (cancelled) return;
+        setProperties([]);
+        setLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [sellerUid]);
+
+  return { properties, loading };
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import type { User } from "firebase/auth"
-import { onAuthStateChange } from "@/lib/auth"
+import { onAuthStateChanged } from "@/lib/auth"
 
 export const useAuth = () => {
   const [user, setUser] = useState<User | null>(null)
@@ -21,9 +21,9 @@ export const useAuth = () => {
       try {
         console.log("Initializing auth state listener...")
 
-        unsubscribe = onAuthStateChange((user) => {
-          console.log("Auth state changed:", user ? `User: ${user.email}` : "No user")
-          setUser(user)
+        unsubscribe = onAuthStateChanged((authUser: User | null) => {
+          console.log("Auth state changed:", authUser ? `User: ${authUser.email}` : "No user")
+          setUser(authUser)
           setLoading(false)
           setError(null)
         })

--- a/lib/buyer-properties.ts
+++ b/lib/buyer-properties.ts
@@ -1,0 +1,143 @@
+import type { PropertyPreviewPayload } from "@/types/chat";
+import type { HomeInspectionRole } from "@/types/home-inspection";
+
+import { setDocument } from "@/lib/firestore";
+
+const toStringValue = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toString();
+  }
+  return "";
+};
+
+const toOptionalString = (value: unknown): string | null => {
+  const text = toStringValue(value).trim();
+  return text.length > 0 ? text : null;
+};
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const resolveThumbnail = (
+  listingPhotos: unknown,
+  previewThumbnail?: string | null,
+): string | null => {
+  if (typeof previewThumbnail === "string" && previewThumbnail.trim().length > 0) {
+    return previewThumbnail.trim();
+  }
+
+  if (typeof listingPhotos === "string" && listingPhotos.trim().length > 0) {
+    return listingPhotos.trim();
+  }
+
+  if (Array.isArray(listingPhotos)) {
+    const candidate = listingPhotos.find(
+      (item): item is string => typeof item === "string" && item.trim().length > 0,
+    );
+    if (candidate) return candidate.trim();
+  }
+
+  return null;
+};
+
+interface BuyerPropertyCreationInput {
+  buyerUid: string;
+  propertyId: string;
+  listingData?: Record<string, unknown> | null;
+  preview?: PropertyPreviewPayload | null;
+  confirmedAt?: string;
+}
+
+export const saveBuyerPropertyFromListing = async ({
+  buyerUid,
+  propertyId,
+  listingData,
+  preview,
+  confirmedAt,
+}: BuyerPropertyCreationInput): Promise<void> => {
+  const sellerUid = toOptionalString(listingData?.userUid);
+  const confirmedBuyerId = toOptionalString(listingData?.confirmedBuyerId);
+  const title =
+    toStringValue(listingData?.title) ||
+    (preview?.title ? preview.title : `ประกาศ ${propertyId}`);
+  const price = toNumberOrNull(listingData?.price ?? preview?.price ?? null);
+  const transactionType =
+    toOptionalString(listingData?.transactionType) ||
+    toOptionalString(preview?.transactionType) ||
+    "sale";
+  const address = toOptionalString(listingData?.address) ?? toOptionalString(preview?.address);
+  const city = toOptionalString(listingData?.city) ?? toOptionalString(preview?.city);
+  const province =
+    toOptionalString(listingData?.province) ?? toOptionalString(preview?.province);
+  const sellerName = toOptionalString(listingData?.sellerName);
+  const sellerPhone = toOptionalString(listingData?.sellerPhone);
+  const sellerEmail = toOptionalString(listingData?.sellerEmail);
+  const thumbnailUrl = resolveThumbnail(listingData?.photos, preview?.thumbnailUrl ?? null);
+  const nowIso = confirmedAt ?? new Date().toISOString();
+
+  const payload: Record<string, unknown> = {
+    propertyId,
+    buyerUid,
+    sellerUid,
+    confirmedBuyerId: confirmedBuyerId || buyerUid,
+    title,
+    price,
+    transactionType,
+    address,
+    city,
+    province,
+    thumbnailUrl,
+    confirmedAt: nowIso,
+    isUnderPurchase: Boolean(listingData?.isUnderPurchase ?? true),
+    buyerConfirmed: true,
+    sellerDocumentsConfirmed: Boolean(listingData?.sellerDocumentsConfirmed),
+    handoverDate: null,
+    handoverNote: "",
+    lastInspectionUpdateAt: null,
+    lastInspectionUpdatedBy: null,
+    sellerName,
+    sellerPhone,
+    sellerEmail,
+  };
+
+  await setDocument(`users/${buyerUid}/buyer_properties`, propertyId, payload);
+};
+
+interface BuyerInspectionUpdateInput {
+  buyerUid: string;
+  propertyId: string;
+  handoverDate?: string | null;
+  handoverNote?: string;
+  lastInspectionUpdatedBy?: HomeInspectionRole;
+}
+
+export const updateBuyerPropertyInspectionStateRecord = async (
+  input: BuyerInspectionUpdateInput,
+): Promise<void> => {
+  const { buyerUid, propertyId, handoverDate, handoverNote, lastInspectionUpdatedBy } = input;
+
+  const payload: Record<string, unknown> = {
+    lastInspectionUpdateAt: new Date().toISOString(),
+  };
+
+  if (Object.prototype.hasOwnProperty.call(input, "handoverDate")) {
+    payload.handoverDate = handoverDate ?? null;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, "handoverNote")) {
+    payload.handoverNote = typeof handoverNote === "string" ? handoverNote : "";
+  }
+
+  if (lastInspectionUpdatedBy) {
+    payload.lastInspectionUpdatedBy = lastInspectionUpdatedBy;
+  }
+
+  await setDocument(`users/${buyerUid}/buyer_properties`, propertyId, payload);
+};

--- a/lib/buyer-property-mapper.ts
+++ b/lib/buyer-property-mapper.ts
@@ -1,0 +1,102 @@
+import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore";
+
+import type { BuyerProperty } from "@/types/buyer-property";
+import type { HomeInspectionRole } from "@/types/home-inspection";
+
+const toStringValue = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toString();
+  }
+  return "";
+};
+
+const toOptionalString = (value: unknown): string | null => {
+  const stringValue = toStringValue(value).trim();
+  return stringValue.length > 0 ? stringValue : null;
+};
+
+const toNumberOrNull = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const toIsoString = (value: unknown): string | null => {
+  if (typeof value === "string") return value;
+  if (
+    value &&
+    typeof value === "object" &&
+    "toDate" in value &&
+    typeof (value as { toDate?: () => Date }).toDate === "function"
+  ) {
+    const date = (value as { toDate: () => Date }).toDate();
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return null;
+};
+
+const toInspectionRole = (value: unknown): HomeInspectionRole | null => {
+  if (value === "buyer" || value === "seller") {
+    return value;
+  }
+  return null;
+};
+
+const resolveThumbnail = (value: unknown): string | null => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  if (Array.isArray(value)) {
+    const firstPhoto = value.find((item) => typeof item === "string" && item.trim().length > 0);
+    return typeof firstPhoto === "string" ? firstPhoto.trim() : null;
+  }
+
+  return null;
+};
+
+export const parseBuyerPropertyConfirmedAt = (confirmedAt: string | null): number => {
+  if (!confirmedAt) return 0;
+  const time = Date.parse(confirmedAt);
+  return Number.isNaN(time) ? 0 : time;
+};
+
+export const mapDocumentToBuyerProperty = (
+  doc: QueryDocumentSnapshot<DocumentData>,
+): BuyerProperty => {
+  const data = doc.data();
+
+  return {
+    id: doc.id,
+    propertyId: toStringValue(data.propertyId) || doc.id,
+    buyerUid:
+      toStringValue(data.buyerUid) ||
+      (doc.ref.parent?.parent ? toStringValue(doc.ref.parent.parent.id) : ""),
+    sellerUid: toOptionalString(data.sellerUid),
+    confirmedBuyerId: toOptionalString(data.confirmedBuyerId),
+    title: toStringValue(data.title),
+    price: toNumberOrNull(data.price),
+    transactionType: toOptionalString(data.transactionType),
+    address: toOptionalString(data.address),
+    city: toOptionalString(data.city),
+    province: toOptionalString(data.province),
+    thumbnailUrl: resolveThumbnail(data.thumbnailUrl ?? data.photos),
+    confirmedAt: toIsoString(data.confirmedAt),
+    isUnderPurchase: Boolean(data.isUnderPurchase),
+    buyerConfirmed: Boolean(data.buyerConfirmed),
+    sellerDocumentsConfirmed: Boolean(data.sellerDocumentsConfirmed),
+    handoverDate: toIsoString(data.handoverDate),
+    handoverNote: toStringValue(data.handoverNote),
+    lastInspectionUpdateAt: toIsoString(data.lastInspectionUpdateAt),
+    lastInspectionUpdatedBy: toInspectionRole(data.lastInspectionUpdatedBy),
+    sellerName: toOptionalString(data.sellerName),
+    sellerPhone: toOptionalString(data.sellerPhone),
+    sellerEmail: toOptionalString(data.sellerEmail),
+  };
+};

--- a/lib/home-inspection.ts
+++ b/lib/home-inspection.ts
@@ -418,7 +418,24 @@ export const updateInspectionState = async (
     lastUpdatedAt: new Date().toISOString(),
   })
 
-  await setDocument(`property/${propertyId}/inspection`, "state", payload)
+  const propertySyncPayload: Record<string, unknown> = {
+    handoverUpdatedAt: payload.lastUpdatedAt,
+    handoverUpdatedBy: updates.lastUpdatedBy,
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, "handoverDate")) {
+    propertySyncPayload.handoverDate = updates.handoverDate ?? null
+  }
+
+  if (Object.prototype.hasOwnProperty.call(updates, "handoverNote")) {
+    propertySyncPayload.handoverNote =
+      typeof updates.handoverNote === "string" ? updates.handoverNote : ""
+  }
+
+  await Promise.all([
+    setDocument(`property/${propertyId}/inspection`, "state", payload),
+    setDocument("property", propertyId, propertySyncPayload),
+  ])
 
   const changes: string[] = []
   if (Object.prototype.hasOwnProperty.call(updates, "handoverDate")) {

--- a/lib/home-inspection.ts
+++ b/lib/home-inspection.ts
@@ -1,0 +1,276 @@
+import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore"
+
+import {
+  addDocument,
+  setDocument,
+  subscribeToCollection,
+  subscribeToDocument,
+  updateDocument,
+} from "@/lib/firestore"
+import type {
+  HomeInspectionChecklistItem,
+  HomeInspectionIssue,
+  HomeInspectionIssueStatus,
+  HomeInspectionRole,
+  HomeInspectionState,
+  SellerChecklistStatus,
+  BuyerChecklistStatus,
+} from "@/types/home-inspection"
+
+const toStringValue = (value: unknown): string => {
+  if (typeof value === "string") return value
+  if (typeof value === "number" && Number.isFinite(value)) return value.toString()
+  return ""
+}
+
+const toOptionalString = (value: unknown): string | null => {
+  const stringValue = toStringValue(value)
+  return stringValue ? stringValue : null
+}
+
+const toIsoString = (value: unknown): string => {
+  if (typeof value === "string") return value
+  if (
+    value &&
+    typeof value === "object" &&
+    "toDate" in value &&
+    typeof (value as { toDate?: () => Date }).toDate === "function"
+  ) {
+    const date = (value as { toDate: () => Date }).toDate()
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+      return date.toISOString()
+    }
+  }
+  return ""
+}
+
+const isSellerStatus = (value: unknown): value is SellerChecklistStatus => {
+  return value === "scheduled" || value === "fixing" || value === "done"
+}
+
+const isBuyerStatus = (value: unknown): value is BuyerChecklistStatus => {
+  return value === "pending" || value === "accepted" || value === "follow-up"
+}
+
+const isIssueStatus = (value: unknown): value is HomeInspectionIssueStatus => {
+  return (
+    value === "pending" ||
+    value === "in-progress" ||
+    value === "buyer-review" ||
+    value === "completed"
+  )
+}
+
+const mapChecklistDoc = (
+  doc: QueryDocumentSnapshot<DocumentData>,
+): HomeInspectionChecklistItem => {
+  const data = doc.data()
+
+  const sellerStatus = isSellerStatus(data.sellerStatus) ? data.sellerStatus : "scheduled"
+  const buyerStatus = isBuyerStatus(data.buyerStatus) ? data.buyerStatus : "pending"
+
+  return {
+    id: doc.id,
+    title: toStringValue(data.title),
+    description: toStringValue(data.description),
+    createdBy: data.createdBy === "seller" ? "seller" : "buyer",
+    sellerStatus,
+    buyerStatus,
+    createdAt: toIsoString(data.createdAt),
+    updatedAt: toIsoString(data.updatedAt),
+  }
+}
+
+const mapIssueDoc = (doc: QueryDocumentSnapshot<DocumentData>): HomeInspectionIssue => {
+  const data = doc.data()
+
+  const status = isIssueStatus(data.status) ? data.status : "pending"
+
+  return {
+    id: doc.id,
+    title: toStringValue(data.title),
+    location: toStringValue(data.location),
+    description: toStringValue(data.description),
+    status,
+    reportedBy: data.reportedBy === "seller" ? "seller" : "buyer",
+    reportedAt: toIsoString(data.reportedAt),
+    updatedAt: toIsoString(data.updatedAt),
+    expectedCompletion: toOptionalString(data.expectedCompletion),
+    resolvedAt: toOptionalString(data.resolvedAt),
+    owner: toOptionalString(data.owner),
+  }
+}
+
+const stateDefaults: HomeInspectionState = {
+  handoverDate: null,
+  handoverNote: "",
+  lastUpdatedAt: null,
+  lastUpdatedBy: null,
+}
+
+const filterUndefined = <T extends Record<string, unknown>>(data: T): T => {
+  return Object.entries(data).reduce((acc, [key, value]) => {
+    if (value !== undefined) {
+      acc[key as keyof T] = value as T[keyof T]
+    }
+    return acc
+  }, {} as T)
+}
+
+export const subscribeToInspectionState = async (
+  propertyId: string,
+  callback: (state: HomeInspectionState) => void,
+): Promise<() => void> => {
+  return subscribeToDocument(
+    `property/${propertyId}/inspection`,
+    "state",
+    (doc) => {
+      if (!doc) {
+        callback(stateDefaults)
+        return
+      }
+
+      const data = doc.data() as Partial<HomeInspectionState> | undefined
+      const handoverDate = toOptionalString(data?.handoverDate) ?? null
+      const note = toStringValue(data?.handoverNote)
+      const lastUpdatedAt = data?.lastUpdatedAt ? toStringValue(data.lastUpdatedAt) : null
+      const lastUpdatedBy = data?.lastUpdatedBy === "seller" ? "seller" : data?.lastUpdatedBy === "buyer" ? "buyer" : null
+
+      callback({
+        handoverDate,
+        handoverNote: note,
+        lastUpdatedAt,
+        lastUpdatedBy,
+      })
+    },
+  )
+}
+
+export const updateInspectionState = async (
+  propertyId: string,
+  updates: Partial<Omit<HomeInspectionState, "lastUpdatedAt" | "lastUpdatedBy">> & {
+    lastUpdatedBy: HomeInspectionRole
+  },
+): Promise<void> => {
+  const payload = filterUndefined({
+    ...updates,
+    handoverDate: updates.handoverDate ?? null,
+    lastUpdatedBy: updates.lastUpdatedBy,
+    lastUpdatedAt: new Date().toISOString(),
+  })
+
+  await setDocument(`property/${propertyId}/inspection`, "state", payload)
+}
+
+export const subscribeToInspectionChecklist = async (
+  propertyId: string,
+  callback: (items: HomeInspectionChecklistItem[]) => void,
+): Promise<() => void> => {
+  return subscribeToCollection(
+    `property/${propertyId}/inspectionChecklist`,
+    (docs) => {
+      const items = docs.map(mapChecklistDoc)
+      items.sort((a, b) => {
+        const timeA = Date.parse(a.updatedAt)
+        const timeB = Date.parse(b.updatedAt)
+        if (Number.isNaN(timeA) || Number.isNaN(timeB)) return 0
+        return timeB - timeA
+      })
+      callback(items)
+    },
+  )
+}
+
+export const createInspectionChecklistItem = async (
+  propertyId: string,
+  input: { title: string; description?: string },
+  createdBy: HomeInspectionRole,
+): Promise<void> => {
+  const now = new Date().toISOString()
+  await addDocument(`property/${propertyId}/inspectionChecklist`, {
+    title: input.title,
+    description: input.description ?? "",
+    createdBy,
+    sellerStatus: createdBy === "seller" ? "fixing" : "scheduled",
+    buyerStatus: "pending",
+    createdAt: now,
+    updatedAt: now,
+  })
+}
+
+export const updateInspectionChecklistItem = async (
+  propertyId: string,
+  itemId: string,
+  updates: Partial<Pick<HomeInspectionChecklistItem, "title" | "description" | "sellerStatus" | "buyerStatus">>,
+): Promise<void> => {
+  const payload = filterUndefined({
+    ...updates,
+    updatedAt: new Date().toISOString(),
+  })
+  await updateDocument(`property/${propertyId}/inspectionChecklist`, itemId, payload)
+}
+
+export const subscribeToInspectionIssues = async (
+  propertyId: string,
+  callback: (issues: HomeInspectionIssue[]) => void,
+): Promise<() => void> => {
+  return subscribeToCollection(
+    `property/${propertyId}/inspectionIssues`,
+    (docs) => {
+      const issues = docs.map(mapIssueDoc)
+      issues.sort((a, b) => {
+        const timeA = Date.parse(a.updatedAt)
+        const timeB = Date.parse(b.updatedAt)
+        if (Number.isNaN(timeA) || Number.isNaN(timeB)) return 0
+        return timeB - timeA
+      })
+      callback(issues)
+    },
+  )
+}
+
+export const createInspectionIssue = async (
+  propertyId: string,
+  input: {
+    title: string
+    location: string
+    description?: string
+    expectedCompletion?: string | null
+    owner?: string | null
+  },
+  reportedBy: HomeInspectionRole,
+): Promise<void> => {
+  const now = new Date().toISOString()
+  await addDocument(`property/${propertyId}/inspectionIssues`, {
+    title: input.title,
+    location: input.location,
+    description: input.description ?? "",
+    status: "pending",
+    reportedBy,
+    reportedAt: now,
+    updatedAt: now,
+    expectedCompletion: input.expectedCompletion ?? null,
+    resolvedAt: null,
+    owner: input.owner ?? null,
+  })
+}
+
+export const updateInspectionIssue = async (
+  propertyId: string,
+  issueId: string,
+  updates: Partial<{
+    title: string
+    location: string
+    description: string
+    status: HomeInspectionIssueStatus
+    expectedCompletion: string | null
+    resolvedAt: string | null
+    owner: string | null
+  }>,
+): Promise<void> => {
+  const payload = filterUndefined({
+    ...updates,
+    updatedAt: new Date().toISOString(),
+  })
+  await updateDocument(`property/${propertyId}/inspectionIssues`, issueId, payload)
+}

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -2,6 +2,7 @@ import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore";
 
 import {
   addDocument,
+  deleteDocument,
   getDocuments,
   subscribeToCollection,
   updateDocument,
@@ -169,4 +170,28 @@ export const markUserNotificationsReadByRelated = async (
       ),
     );
   }
+};
+
+export const deleteUserNotificationsByRelatedId = async (
+  userId: string,
+  relatedId: string,
+): Promise<void> => {
+  if (!relatedId) return;
+
+  const { where } = await import("firebase/firestore");
+
+  const docs = await getDocuments(
+    `users/${userId}/notifications`,
+    where("relatedId", "==", relatedId),
+  );
+
+  if (docs.length === 0) return;
+
+  await Promise.all(
+    docs.map((doc) =>
+      deleteDocument(`users/${userId}/notifications`, doc.id).catch((error) => {
+        console.error("Failed to delete user notification", error);
+      }),
+    ),
+  );
 };

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,172 @@
+import type { DocumentData, QueryDocumentSnapshot } from "firebase/firestore";
+
+import {
+  addDocument,
+  getDocuments,
+  subscribeToCollection,
+  updateDocument,
+} from "@/lib/firestore";
+import type {
+  UserNotification,
+  UserNotificationActionType,
+  UserNotificationCategory,
+} from "@/types/notifications";
+
+const toStringValue = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value.toString();
+  return "";
+};
+
+const toOptionalString = (value: unknown): string | null => {
+  const stringValue = toStringValue(value);
+  return stringValue ? stringValue : null;
+};
+
+const toIsoString = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (
+    value &&
+    typeof value === "object" &&
+    "toDate" in value &&
+    typeof (value as { toDate?: () => Date }).toDate === "function"
+  ) {
+    const date = (value as { toDate: () => Date }).toDate();
+    if (date instanceof Date && !Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return "";
+};
+
+const isNotificationCategory = (
+  value: unknown,
+): value is UserNotificationCategory => {
+  return value === "inspection" || value === "message" || value === "system";
+};
+
+const isActionType = (value: unknown): value is Exclude<UserNotificationActionType, null> => {
+  return value === "navigate" || value === "open-chat";
+};
+
+const mapUserNotificationDoc = (
+  doc: QueryDocumentSnapshot<DocumentData>,
+): UserNotification => {
+  const data = doc.data();
+
+  const category = isNotificationCategory(data.category) ? data.category : "system";
+  const actionType = isActionType(data.actionType) ? data.actionType : null;
+
+  return {
+    id: doc.id,
+    title: toStringValue(data.title),
+    message: toStringValue(data.message),
+    category,
+    createdAt: toIsoString(data.createdAt),
+    read: Boolean(data.read),
+    context: toOptionalString(data.context),
+    relatedId: toOptionalString(data.relatedId),
+    actionType,
+    actionTarget: toOptionalString(data.actionTarget),
+    actionHref: toOptionalString(data.actionHref),
+  };
+};
+
+export const createUserNotification = async (
+  userId: string,
+  input: {
+    title: string;
+    message: string;
+    category: UserNotificationCategory;
+    context?: string | null;
+    relatedId?: string | null;
+    actionType?: UserNotificationActionType;
+    actionTarget?: string | null;
+    actionHref?: string | null;
+  },
+): Promise<void> => {
+  const now = new Date().toISOString();
+
+  await addDocument(`users/${userId}/notifications`, {
+    title: input.title,
+    message: input.message,
+    category: input.category,
+    context: input.context ?? null,
+    relatedId: input.relatedId ?? null,
+    actionType: input.actionType ?? null,
+    actionTarget: input.actionTarget ?? null,
+    actionHref: input.actionHref ?? null,
+    createdAt: now,
+    read: false,
+  });
+};
+
+export const subscribeToUserNotifications = async (
+  userId: string,
+  callback: (notifications: UserNotification[]) => void,
+): Promise<() => void> => {
+  return subscribeToCollection(`users/${userId}/notifications`, (docs) => {
+    const notifications = docs.map(mapUserNotificationDoc);
+
+    notifications.sort((a, b) => {
+      const timeA = Date.parse(a.createdAt);
+      const timeB = Date.parse(b.createdAt);
+      if (Number.isNaN(timeA) || Number.isNaN(timeB)) {
+        return 0;
+      }
+      return timeB - timeA;
+    });
+
+    callback(notifications);
+  });
+};
+
+export const markUserNotificationsRead = async (
+  userId: string,
+  notificationIds: string[],
+): Promise<void> => {
+  if (notificationIds.length === 0) return;
+
+  await Promise.all(
+    notificationIds.map((id) =>
+      updateDocument(`users/${userId}/notifications`, id, {
+        read: true,
+      }),
+    ),
+  );
+};
+
+const chunkArray = <T,>(items: T[], size: number): T[][] => {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result;
+};
+
+export const markUserNotificationsReadByRelated = async (
+  userId: string,
+  relatedIds: string[],
+): Promise<void> => {
+  if (relatedIds.length === 0) return;
+
+  const chunks = chunkArray(Array.from(new Set(relatedIds)), 10);
+
+  for (const chunk of chunks) {
+    const { where } = await import("firebase/firestore");
+    const docs = await getDocuments(
+      `users/${userId}/notifications`,
+      where("relatedId", "in", chunk),
+    );
+
+    if (docs.length === 0) continue;
+
+    await Promise.all(
+      docs.map((doc) =>
+        updateDocument(`users/${userId}/notifications`, doc.id, {
+          read: true,
+        }),
+      ),
+    );
+  }
+};

--- a/lib/property-preview.ts
+++ b/lib/property-preview.ts
@@ -1,0 +1,97 @@
+import type { PropertyPreviewPayload } from "@/types/chat"
+
+export const sanitizePropertyPreview = (
+  preview: PropertyPreviewPayload,
+): PropertyPreviewPayload => {
+  return {
+    propertyId: preview.propertyId,
+    ownerUid: preview.ownerUid,
+    title: preview.title,
+    price: typeof preview.price === "number" ? preview.price : null,
+    transactionType:
+      typeof preview.transactionType === "string" ? preview.transactionType : null,
+    thumbnailUrl:
+      typeof preview.thumbnailUrl === "string" && preview.thumbnailUrl.trim().length > 0
+        ? preview.thumbnailUrl
+        : null,
+    address:
+      typeof preview.address === "string" && preview.address.trim().length > 0
+        ? preview.address
+        : null,
+    city:
+      typeof preview.city === "string" && preview.city.trim().length > 0
+        ? preview.city
+        : null,
+    province:
+      typeof preview.province === "string" && preview.province.trim().length > 0
+        ? preview.province
+        : null,
+  }
+}
+
+export const buildPreviewFromPropertyRecord = (
+  propertyId: string,
+  record: Record<string, unknown>,
+): PropertyPreviewPayload | null => {
+  const ownerUid =
+    typeof record.userUid === "string" && record.userUid.trim().length > 0
+      ? record.userUid
+      : null
+
+  const title =
+    typeof record.title === "string" && record.title.trim().length > 0
+      ? record.title
+      : null
+
+  if (!ownerUid || !title) {
+    return null
+  }
+
+  let price: number | null = null
+  if (typeof record.price === "number" && Number.isFinite(record.price)) {
+    price = record.price
+  } else if (typeof record.price === "string") {
+    const parsed = Number(record.price)
+    price = Number.isFinite(parsed) ? parsed : null
+  }
+
+  const transactionType =
+    typeof record.transactionType === "string" && record.transactionType.trim().length > 0
+      ? record.transactionType
+      : null
+
+  const address =
+    typeof record.address === "string" && record.address.trim().length > 0
+      ? record.address
+      : null
+
+  const city =
+    typeof record.city === "string" && record.city.trim().length > 0 ? record.city : null
+
+  const province =
+    typeof record.province === "string" && record.province.trim().length > 0
+      ? record.province
+      : null
+
+  let thumbnailUrl: string | null = null
+  if (typeof record.photos === "string" && record.photos.trim().length > 0) {
+    thumbnailUrl = record.photos
+  } else if (Array.isArray(record.photos)) {
+    const firstPhoto = record.photos.find(
+      (value): value is string => typeof value === "string" && value.trim().length > 0,
+    )
+    thumbnailUrl = firstPhoto ?? null
+  }
+
+  return sanitizePropertyPreview({
+    propertyId,
+    ownerUid,
+    title,
+    price,
+    transactionType,
+    thumbnailUrl,
+    address,
+    city,
+    province,
+  })
+}

--- a/lib/property-purchase.ts
+++ b/lib/property-purchase.ts
@@ -1,0 +1,245 @@
+import { deleteDocument, getDocument, getDocuments, setDocument } from "@/lib/firestore"
+import {
+  createUserNotification,
+  deleteUserNotificationsByRelatedId,
+} from "@/lib/notifications"
+import { deleteFile, extractStoragePathFromUrl } from "@/lib/storage"
+
+const toStringValue = (value: unknown): string => {
+  if (typeof value === "string") return value
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toString()
+  }
+  return ""
+}
+
+const toOptionalString = (value: unknown): string | null => {
+  const text = toStringValue(value).trim()
+  return text.length > 0 ? text : null
+}
+
+type CancelInitiator = "buyer" | "seller"
+
+interface PropertyParticipants {
+  sellerUid: string | null
+  buyerUid: string | null
+  title: string | null
+}
+
+const resolvePropertyParticipants = async (
+  propertyId: string,
+): Promise<PropertyParticipants> => {
+  const doc = await getDocument("property", propertyId)
+  if (!doc) {
+    throw new Error("ไม่พบประกาศสำหรับการยกเลิก")
+  }
+
+  const data = doc.data() as Record<string, unknown>
+
+  return {
+    sellerUid: toOptionalString(data.userUid),
+    buyerUid: toOptionalString(data.confirmedBuyerId),
+    title: toOptionalString(data.title),
+  }
+}
+
+const cleanInspectionCollection = async (propertyId: string): Promise<void> => {
+  try {
+    await deleteDocument(`property/${propertyId}/inspection`, "state")
+  } catch (error) {
+    console.error("Failed to delete inspection state", error)
+  }
+
+  try {
+    const checklistDocs = await getDocuments(`property/${propertyId}/inspectionChecklist`)
+    await Promise.all(
+      checklistDocs.map((doc) =>
+        deleteDocument(`property/${propertyId}/inspectionChecklist`, doc.id).catch((err) => {
+          console.error("Failed to delete inspection checklist", err)
+        }),
+      ),
+    )
+  } catch (error) {
+    console.error("Failed to clean inspection checklist", error)
+  }
+
+  let photoPaths: string[] = []
+
+  try {
+    const issueDocs = await getDocuments(`property/${propertyId}/inspectionIssues`)
+
+    photoPaths = issueDocs.reduce<string[]>((paths, doc) => {
+      const data = doc.data() as Record<string, unknown>
+      const collectPaths = (value: unknown) => {
+        if (!Array.isArray(value)) return
+        for (const entry of value) {
+          if (!entry || typeof entry !== "object") continue
+          const record = entry as Record<string, unknown>
+          const storagePath = toOptionalString(record.storagePath)
+          if (storagePath) {
+            paths.push(storagePath)
+            continue
+          }
+          const url = toOptionalString(record.url)
+          if (url) {
+            const maybePath = extractStoragePathFromUrl(url)
+            if (maybePath) {
+              paths.push(maybePath)
+            }
+          }
+        }
+      }
+
+      collectPaths(data.beforePhotos)
+      collectPaths(data.afterPhotos)
+
+      return paths
+    }, [])
+
+    await Promise.all(
+      issueDocs.map((doc) =>
+        deleteDocument(`property/${propertyId}/inspectionIssues`, doc.id).catch((err) => {
+          console.error("Failed to delete inspection issue", err)
+        }),
+      ),
+    )
+  } catch (error) {
+    console.error("Failed to clean inspection issues", error)
+  }
+
+  if (photoPaths.length > 0) {
+    const uniquePaths = Array.from(new Set(photoPaths))
+    await Promise.all(
+      uniquePaths.map((path) =>
+        deleteFile(path).catch((error) => {
+          console.error("Failed to delete inspection photo", error)
+        }),
+      ),
+    )
+  }
+
+  try {
+    const notificationDocs = await getDocuments(`property/${propertyId}/inspectionNotifications`)
+    await Promise.all(
+      notificationDocs.map((doc) =>
+        deleteDocument(`property/${propertyId}/inspectionNotifications`, doc.id).catch((err) => {
+          console.error("Failed to delete inspection notification", err)
+        }),
+      ),
+    )
+  } catch (error) {
+    console.error("Failed to clean inspection notifications", error)
+  }
+}
+
+const notifyCancellation = async (
+  propertyId: string,
+  participants: PropertyParticipants,
+  initiatedBy: CancelInitiator,
+): Promise<void> => {
+  const title = participants.title ? `ทรัพย์ ${participants.title}` : "ประกาศของคุณ"
+
+  const notifications: Promise<void>[] = []
+
+  if (participants.buyerUid) {
+    const buyerMessage =
+      initiatedBy === "buyer"
+        ? "คุณยกเลิกรายการซื้อแล้ว ระบบได้ล้างข้อมูลการตรวจให้เรียบร้อย"
+        : "ผู้ขายยกเลิกรายการซื้อแล้ว รายการนี้ถูกลบออกจากรายการของคุณ"
+
+    notifications.push(
+      createUserNotification(participants.buyerUid, {
+        title: initiatedBy === "buyer" ? "ยกเลิกการซื้อเรียบร้อย" : "ผู้ขายยกเลิกการซื้อ",
+        message: `${title} • ${buyerMessage}`,
+        category: "system",
+        relatedId: propertyId,
+        actionType: "navigate",
+        actionHref: "/buy/my-properties",
+      }).catch((error) => {
+        console.error("Failed to notify buyer cancellation", error)
+      }),
+    )
+  }
+
+  if (participants.sellerUid) {
+    const sellerMessage =
+      initiatedBy === "seller"
+        ? "คุณได้ยกเลิกการซื้อและระบบคืนสถานะประกาศให้เรียบร้อย"
+        : "ผู้ซื้อยกเลิกการซื้อแล้ว คุณสามารถรอผู้สนใจรายถัดไปได้"
+
+    notifications.push(
+      createUserNotification(participants.sellerUid, {
+        title: initiatedBy === "seller" ? "ยกเลิกการซื้อเรียบร้อย" : "ผู้ซื้อยกเลิกการซื้อ",
+        message: `${title} • ${sellerMessage}`,
+        category: "system",
+        relatedId: propertyId,
+        actionType: "navigate",
+        actionHref: "/sell",
+      }).catch((error) => {
+        console.error("Failed to notify seller cancellation", error)
+      }),
+    )
+  }
+
+  if (notifications.length > 0) {
+    await Promise.all(notifications)
+  }
+}
+
+export const cancelPropertyPurchase = async (
+  propertyId: string,
+  initiatedBy: CancelInitiator,
+): Promise<void> => {
+  const participants = await resolvePropertyParticipants(propertyId)
+
+  if (!participants.buyerUid) {
+    throw new Error("ประกาศนี้ไม่มีผู้ซื้อที่ยืนยันอยู่")
+  }
+
+  await Promise.all([
+    setDocument("property", propertyId, {
+      isUnderPurchase: false,
+      confirmedBuyerId: null,
+      buyerConfirmed: false,
+      sellerDocumentsConfirmed: false,
+    }),
+    participants.sellerUid
+      ? setDocument(`users/${participants.sellerUid}/user_property`, propertyId, {
+          isUnderPurchase: false,
+          confirmedBuyerId: null,
+          buyerConfirmed: false,
+          sellerDocumentsConfirmed: false,
+        })
+      : Promise.resolve(),
+    deleteDocument(`users/${participants.buyerUid}/buyer_properties`, propertyId).catch((error) => {
+      console.error("Failed to delete buyer property record", error)
+    }),
+  ])
+
+  await cleanInspectionCollection(propertyId)
+
+  const notificationCleanups: Promise<void>[] = []
+
+  if (participants.buyerUid) {
+    notificationCleanups.push(
+      deleteUserNotificationsByRelatedId(participants.buyerUid, propertyId).catch((error) => {
+        console.error("Failed to delete buyer notifications for property", error)
+      }),
+    )
+  }
+
+  if (participants.sellerUid) {
+    notificationCleanups.push(
+      deleteUserNotificationsByRelatedId(participants.sellerUid, propertyId).catch((error) => {
+        console.error("Failed to delete seller notifications for property", error)
+      }),
+    )
+  }
+
+  if (notificationCleanups.length > 0) {
+    await Promise.all(notificationCleanups)
+  }
+
+  await notifyCancellation(propertyId, participants, initiatedBy)
+}
+

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,10 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_")
+}
+
 // Normalize phone numbers to E.164.
 // Removes non-digit characters and converts Thai numbers
 // starting with "0" to use the "+66" country code.

--- a/types/buyer-property.ts
+++ b/types/buyer-property.ts
@@ -1,0 +1,27 @@
+import type { HomeInspectionRole } from "@/types/home-inspection";
+
+export interface BuyerProperty {
+  id: string;
+  propertyId: string;
+  buyerUid: string;
+  sellerUid: string | null;
+  confirmedBuyerId: string | null;
+  title: string;
+  price: number | null;
+  transactionType: string | null;
+  address: string | null;
+  city: string | null;
+  province: string | null;
+  thumbnailUrl: string | null;
+  confirmedAt: string | null;
+  isUnderPurchase: boolean;
+  buyerConfirmed: boolean;
+  sellerDocumentsConfirmed: boolean;
+  handoverDate: string | null;
+  handoverNote: string;
+  lastInspectionUpdateAt: string | null;
+  lastInspectionUpdatedBy: HomeInspectionRole | null;
+  sellerName: string | null;
+  sellerPhone: string | null;
+  sellerEmail: string | null;
+}

--- a/types/home-inspection.ts
+++ b/types/home-inspection.ts
@@ -1,0 +1,42 @@
+export type HomeInspectionRole = "buyer" | "seller";
+
+export interface HomeInspectionState {
+  handoverDate: string | null;
+  handoverNote: string;
+  lastUpdatedBy: HomeInspectionRole | null;
+  lastUpdatedAt: string | null;
+}
+
+export type BuyerChecklistStatus = "pending" | "accepted" | "follow-up";
+export type SellerChecklistStatus = "scheduled" | "fixing" | "done";
+
+export interface HomeInspectionChecklistItem {
+  id: string;
+  title: string;
+  description: string;
+  createdBy: HomeInspectionRole;
+  buyerStatus: BuyerChecklistStatus;
+  sellerStatus: SellerChecklistStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type HomeInspectionIssueStatus =
+  | "pending"
+  | "in-progress"
+  | "buyer-review"
+  | "completed";
+
+export interface HomeInspectionIssue {
+  id: string;
+  title: string;
+  location: string;
+  description: string;
+  status: HomeInspectionIssueStatus;
+  reportedBy: HomeInspectionRole;
+  reportedAt: string;
+  updatedAt: string;
+  expectedCompletion?: string | null;
+  resolvedAt?: string | null;
+  owner?: string | null;
+}

--- a/types/home-inspection.ts
+++ b/types/home-inspection.ts
@@ -61,3 +61,7 @@ export interface HomeInspectionNotification {
   relatedId?: string | null;
   read: boolean;
 }
+
+export interface HomeInspectionNotificationCountDetail {
+  count: number;
+}

--- a/types/home-inspection.ts
+++ b/types/home-inspection.ts
@@ -40,3 +40,24 @@ export interface HomeInspectionIssue {
   resolvedAt?: string | null;
   owner?: string | null;
 }
+
+export type HomeInspectionNotificationAudience = "buyer" | "seller" | "all";
+
+export type HomeInspectionNotificationCategory =
+  | "general"
+  | "schedule"
+  | "checklist"
+  | "issue"
+  | "note";
+
+export interface HomeInspectionNotification {
+  id: string;
+  title: string;
+  message: string;
+  category: HomeInspectionNotificationCategory;
+  audience: HomeInspectionNotificationAudience;
+  createdAt: string;
+  triggeredBy: HomeInspectionRole;
+  relatedId?: string | null;
+  read: boolean;
+}

--- a/types/home-inspection.ts
+++ b/types/home-inspection.ts
@@ -62,6 +62,3 @@ export interface HomeInspectionNotification {
   read: boolean;
 }
 
-export interface HomeInspectionNotificationCountDetail {
-  count: number;
-}

--- a/types/home-inspection.ts
+++ b/types/home-inspection.ts
@@ -10,6 +10,14 @@ export interface HomeInspectionState {
 export type BuyerChecklistStatus = "pending" | "accepted" | "follow-up";
 export type SellerChecklistStatus = "scheduled" | "fixing" | "done";
 
+export interface HomeInspectionIssuePhoto {
+  id: string;
+  url: string;
+  storagePath?: string | null;
+  uploadedAt: string;
+  uploadedBy: HomeInspectionRole;
+}
+
 export interface HomeInspectionChecklistItem {
   id: string;
   title: string;
@@ -39,6 +47,8 @@ export interface HomeInspectionIssue {
   expectedCompletion?: string | null;
   resolvedAt?: string | null;
   owner?: string | null;
+  beforePhotos: HomeInspectionIssuePhoto[];
+  afterPhotos: HomeInspectionIssuePhoto[];
 }
 
 export type HomeInspectionNotificationAudience = "buyer" | "seller" | "all";

--- a/types/notifications.ts
+++ b/types/notifications.ts
@@ -1,0 +1,17 @@
+export type UserNotificationCategory = "inspection" | "message" | "system";
+
+export type UserNotificationActionType = "navigate" | "open-chat" | null;
+
+export interface UserNotification {
+  id: string;
+  title: string;
+  message: string;
+  category: UserNotificationCategory;
+  createdAt: string;
+  read: boolean;
+  context?: string | null;
+  relatedId?: string | null;
+  actionType?: UserNotificationActionType;
+  actionTarget?: string | null;
+  actionHref?: string | null;
+}

--- a/types/property-purchase-status.ts
+++ b/types/property-purchase-status.ts
@@ -1,0 +1,6 @@
+export interface PropertyPurchaseStatus {
+  isUnderPurchase: boolean
+  confirmedBuyerId: string | null
+  buyerConfirmed: boolean
+  sellerDocumentsConfirmed: boolean
+}


### PR DESCRIPTION
## Summary
- add a dedicated home inspection workflow page with handover scheduling, collaborative checklists, defect tracking, and a milestone calendar
- allow sellers to jump from the document checklist to the new workflow and share a link with buyers once documents are confirmed

## Testing
- pnpm lint *(fails: Next.js interactive lint config prompt in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e00eb020a4832180bf2a8c07a6e045