### PR TITLE
Expand share modal width

### DIFF
--- a/components/property-share-modal.tsx
+++ b/components/property-share-modal.tsx
@@ -23,7 +23,7 @@ export function PropertyShareModal({
 }: PropertyShareModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>แชร์ประกาศของคุณ</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- enlarge the property share dialog to use a wider max width so the share content fits comfortably

## Testing
- npm run lint *(fails: prompts for Next.js ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e1621cbf908321a44cc7621a01379c