### PR TITLE
feat: update DreamHome favicon

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,11 @@ export const metadata: Metadata = {
   formatDetection: { email: false, address: false, telephone: false },
   metadataBase: new URL("https://dreamhome.com"),
   alternates: { canonical: "/" },
+  icons: {
+    icon: "/dreamhome-favicon.svg",
+    shortcut: "/dreamhome-favicon.svg",
+    apple: "/dreamhome-favicon.svg",
+  },
   openGraph: {
     title: "DreamHome - ค้นหาบ้านในฝันของคุณ",
     description: "แพลตฟอร์มอสังหาริมทรัพย์ออนไลน์ที่ดีที่สุดในประเทศไทย",

--- a/public/dreamhome-favicon.svg
+++ b/public/dreamhome-favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#2563EB"/>
+  <path d="M32 14L14 28.5V50H26V36H38V50H50V28.5L32 14Z" fill="white"/>
+  <path d="M32 22L20 32V46H28V34H36V46H44V32L32 22Z" fill="#BFDBFE"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a DreamHome-branded favicon asset
- register the new icon in the global metadata so the browser tab uses it

## Testing
- not run (eslint prompts for setup when running `npm run lint`)


------
https://chatgpt.com/codex/tasks/task_e_68e4c42ae0048321bbed7f1742625bb4