### PR TITLE
Enhance layout styling across DreamHome pages

### DIFF
--- a/app/buy/page.tsx
+++ b/app/buy/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useMemo, useState } from "react"
 import { useRouter, useSearchParams, type ReadonlyURLSearchParams } from "next/navigation"
-import { Inter } from "next/font/google"
 
 import HeroSection from "@/components/hero-section"
 import FeaturedProperties from "@/components/featured-properties"
@@ -14,8 +13,6 @@ import {
   DEFAULT_LOCATION_RADIUS_KM,
   MAP_LOCATION_FALLBACK_LABEL,
 } from "@/types/location-filter"
-
-const inter = Inter({ subsets: ["latin"] })
 
 type PriceRange = {
   min: number | null
@@ -239,7 +236,7 @@ export default function BuyPage() {
   }, [])
 
   return (
-    <div className={`${inter.className} bg-gray-50`}>
+    <>
       <HeroSection
         searchTerm={searchTerm}
         selectedPropertyType={selectedPropertyType}
@@ -260,6 +257,6 @@ export default function BuyPage() {
         initialValue={locationFilter}
         onApply={handleLocationApplied}
       />
-    </div>
+    </>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,10 +5,6 @@
 
 
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 *,
 *::before,
 *::after {
@@ -113,10 +109,53 @@ iframe {
 }
 
 @layer base {
+  :root {
+    --page-shell-gap: 3rem;
+  }
+
   * {
     @apply border-border;
   }
+
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+    background-image: linear-gradient(180deg, rgba(226, 232, 240, 0.7), rgba(203, 213, 225, 0.3));
+    min-height: 100vh;
+  }
+
+  main {
+    @apply flex-1;
+  }
+}
+
+@layer components {
+  .page-shell {
+    @apply flex flex-col gap-16;
+  }
+
+  .surface-card {
+    @apply rounded-3xl border border-slate-200/70 bg-white/80 shadow-lg shadow-slate-200/40 backdrop-blur;
+  }
+
+  .full-bleed {
+    margin-left: -1rem;
+    margin-right: -1rem;
+    width: calc(100% + 2rem);
+  }
+
+  @screen sm {
+    .full-bleed {
+      margin-left: -1.5rem;
+      margin-right: -1.5rem;
+      width: calc(100% + 3rem);
+    }
+  }
+
+  @screen lg {
+    .full-bleed {
+      margin-left: -2rem;
+      margin-right: -2rem;
+      width: calc(100% + 4rem);
+    }
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -61,7 +61,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="th" suppressHydrationWarning>
       {/* เพิ่ม suppressHydrationWarning ที่ body ด้วยเพื่อกัน attribute mismatch บางกรณี */}
-      <body className={inter.className} suppressHydrationWarning>
+      <body
+        className={`${inter.className} bg-slate-100 text-slate-900 antialiased`}
+        suppressHydrationWarning
+      >
         <ClientOnly>
           <ThemeProvider
             attribute="class"
@@ -79,9 +82,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   aria-hidden="true"
                 />
 
-                <div className="min-h-screen flex flex-col">
+                <div className="flex min-h-screen flex-col">
                   <Navigation />
-                  <main className="flex-1">{children}</main>
+                  <main className="flex-1">
+                    <div className="mx-auto w-full max-w-7xl px-4 pb-20 pt-10 sm:px-6 lg:px-8">
+                      <div className="page-shell">{children}</div>
+                    </div>
+                  </main>
                   <Footer />
                 </div>
                 <Toaster />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import { Inter } from "next/font/google"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -20,16 +19,14 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 
-const inter = Inter({ subsets: ["latin"] })
-
 export default function Home() {
   return (
-    <div className={`${inter.className} bg-gray-50 text-gray-900`}>
+    <>
       {/* HERO SECTION */}
-      <section className="relative overflow-hidden">
+      <section className="full-bleed relative overflow-hidden rounded-3xl shadow-xl shadow-emerald-900/20">
         <div className="absolute inset-0 bg-gradient-to-br from-emerald-500 via-emerald-600 to-teal-700" />
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20 lg:py-24 text-white">
-          <div className="text-center">
+        <div className="relative px-6 py-16 text-white sm:px-10 sm:py-20 lg:px-16 lg:py-24">
+          <div className="mx-auto max-w-4xl text-center">
             <Badge className="bg-white/10 hover:bg-white/15 text-white border border-white/20 mb-6">
               เกี่ยวกับ DreamHome
             </Badge>
@@ -62,14 +59,13 @@ export default function Home() {
       </section>
 
       {/* MISSION & VISION */}
-      <section className="py-16 sm:py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">พันธกิจและวิสัยทัศน์</h2>
-            <p className="text-gray-600 max-w-2xl mx-auto">เราตั้งใจที่จะเปลี่ยนแปลงวิธีการซื้อขายอสังหาริมทรัพย์ให้ดีขึ้น</p>
-          </div>
+      <section className="surface-card px-6 py-12 sm:py-16">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">พันธกิจและวิสัยทัศน์</h2>
+          <p className="text-gray-600 max-w-2xl mx-auto">เราตั้งใจที่จะเปลี่ยนแปลงวิธีการซื้อขายอสังหาริมทรัพย์ให้ดีขึ้น</p>
+        </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
             <Card className="shadow-sm hover:shadow-md transition">
               <CardHeader>
                 <div className="h-12 w-12 rounded-lg bg-emerald-100 text-emerald-700 flex items-center justify-center mb-4">
@@ -123,20 +119,18 @@ export default function Home() {
                 </ul>
               </CardContent>
             </Card>
-          </div>
         </div>
       </section>
 
       {/* FEATURES */}
-      <section className="py-16 sm:py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 mb-4">คุณสมบัติเด่น</Badge>
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">ทำไมต้องเลือก DreamHome?</h2>
-            <p className="text-gray-600 max-w-2xl mx-auto">เราให้บริการครบวงจรด้วยเทคโนโลยีที่ทันสมัยและทีมงานมืออาชีพ</p>
-          </div>
+      <section className="surface-card px-6 py-12 sm:py-16">
+        <div className="text-center mb-12">
+          <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 mb-4">คุณสมบัติเด่น</Badge>
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">ทำไมต้องเลือก DreamHome?</h2>
+          <p className="text-gray-600 max-w-2xl mx-auto">เราให้บริการครบวงจรด้วยเทคโนโลยีที่ทันสมัยและทีมงานมืออาชีพ</p>
+        </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-12 gap-6">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-12">
             <Card className="shadow-sm hover:shadow-md transition h-full lg:col-span-4">
               <CardHeader className="items-center text-center">
                 <div className="h-10 w-10 rounded-lg bg-emerald-100 text-emerald-700 flex items-center justify-center">
@@ -196,19 +190,17 @@ export default function Home() {
                 ทีมงานมืออาชีพพร้อมให้คำปรึกษาและช่วยเหลือตลอด 24 ชั่วโมง
               </CardContent>
             </Card>
-          </div>
         </div>
       </section>
 
       {/* STATISTICS */}
-      <section className="py-16 sm:py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">ตัวเลขที่น่าประทับใจ</h2>
-            <p className="text-gray-600 max-w-2xl mx-auto">ความไว้วางใจจากลูกค้าหลายพันคนทั่วประเทศ</p>
-          </div>
+      <section className="surface-card px-6 py-12 sm:py-16">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">ตัวเลขที่น่าประทับใจ</h2>
+          <p className="text-gray-600 max-w-2xl mx-auto">ความไว้วางใจจากลูกค้าหลายพันคนทั่วประเทศ</p>
+        </div>
 
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
+        <div className="grid grid-cols-2 gap-8 lg:grid-cols-4">
             <div className="text-center">
               <div className="h-16 w-16 rounded-full bg-emerald-100 text-emerald-700 flex items-center justify-center mx-auto mb-4">
                 <Building2 className="h-8 w-8" />
@@ -240,19 +232,17 @@ export default function Home() {
               <div className="text-3xl font-bold text-gray-900 mb-2">24/7</div>
               <div className="text-gray-600">บริการลูกค้า</div>
             </div>
-          </div>
         </div>
       </section>
 
       {/* HOW IT WORKS */}
-      <section className="py-16 sm:py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 mb-4">วิธีการใช้งาน</Badge>
-            <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">ใช้งานง่ายเพียง 3 ขั้นตอน</h2>
-          </div>
+      <section className="surface-card px-6 py-12 sm:py-16">
+        <div className="text-center mb-12">
+          <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 mb-4">วิธีการใช้งาน</Badge>
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight mb-4">ใช้งานง่ายเพียง 3 ขั้นตอน</h2>
+        </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
             <div className="text-center">
               <div className="h-16 w-16 rounded-full bg-emerald-600 text-white flex items-center justify-center mx-auto mb-6 text-2xl font-bold">
                 1
@@ -276,13 +266,12 @@ export default function Home() {
               <h3 className="text-xl font-semibold mb-4">ติดต่อและปิดดีล</h3>
               <p className="text-gray-600">แชทกับเจ้าของบ้านหรือผู้สนใจ นัดดูบ้าน และปิดการขายได้อย่างปลอดภัย</p>
             </div>
-          </div>
         </div>
       </section>
 
       {/* FAQ */}
-      <section className="py-16 sm:py-20 bg-white">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="surface-card px-6 py-12 sm:py-16">
+        <div className="mx-auto max-w-3xl">
           <div className="text-center mb-12">
             <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200 mb-4">คำถามที่พบบ่อย</Badge>
             <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">FAQ</h2>
@@ -328,8 +317,8 @@ export default function Home() {
       </section>
 
       {/* CTA */}
-      <section className="py-16 sm:py-20 bg-emerald-600 text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <section className="full-bleed rounded-3xl bg-gradient-to-r from-emerald-600 via-teal-600 to-cyan-600 px-6 py-16 text-white shadow-2xl sm:px-10 sm:py-20">
+        <div className="mx-auto max-w-4xl text-center">
           <h2 className="text-3xl sm:text-4xl font-bold mb-4">พร้อมเริ่มต้นแล้วหรือยัง?</h2>
           <p className="text-xl mb-8 opacity-90">เข้าร่วมกับผู้ใช้หลายพันคนที่เชื่อมั่นใน DreamHome</p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -351,6 +340,6 @@ export default function Home() {
         </div>
       </section>
 
-    </div>
+    </>
   )
 }

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams, type ReadonlyURLSearchParams } from "next/navigation"
-import { Inter } from "next/font/google"
 import { ArrowLeft } from "lucide-react"
 
 import HeroSection from "@/components/hero-section"
@@ -16,8 +15,6 @@ import {
   DEFAULT_LOCATION_RADIUS_KM,
   MAP_LOCATION_FALLBACK_LABEL,
 } from "@/types/location-filter"
-
-const inter = Inter({ subsets: ["latin"] })
 
 const parseNumericInput = (value: string): number | null => {
   if (!value) return null
@@ -469,18 +466,15 @@ export default function SearchPage() {
   }, [handleLocationApplied, locationFilter])
 
   return (
-    <div className={`${inter.className} bg-gray-50`}>
-      <div className="border-b border-gray-200 bg-white">
-        <div className="mx-auto flex max-w-7xl items-center gap-2 px-4 py-3 sm:px-6 lg:px-8">
-          <ArrowLeft className="h-4 w-4 text-blue-600" />
-          <Link
-            href="/buy"
-            className="text-sm font-medium text-blue-600 transition hover:text-blue-700"
-          >
+    <>
+      <section className="surface-card px-6 py-4">
+        <div className="flex flex-wrap items-center gap-3 text-sm text-blue-700">
+          <ArrowLeft className="h-4 w-4" />
+          <Link href="/buy" className="font-semibold hover:text-blue-800">
             กลับสู่หน้าซื้ออสังหาริมทรัพย์
           </Link>
         </div>
-      </div>
+      </section>
       <HeroSection
         searchTerm={searchTerm}
         selectedPropertyType={selectedPropertyType}
@@ -521,6 +515,6 @@ export default function SearchPage() {
         initialValue={locationFilter}
         onApply={handleLocationApplied}
       />
-    </div>
+    </>
   )
 }

--- a/components/call-to-action.tsx
+++ b/components/call-to-action.tsx
@@ -3,8 +3,8 @@ import { Search, Plus } from "lucide-react"
 
 export default function CallToAction() {
   return (
-    <section className="bg-blue-600 py-16 text-white">
-      <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 text-center sm:px-6 lg:px-8">
+    <section className="full-bleed rounded-3xl bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-600 px-6 py-16 text-white shadow-2xl sm:px-10 sm:py-20">
+      <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 text-center">
         <Link
           href="/search"
           className="inline-flex items-center justify-center rounded-full bg-white px-8 py-3 font-semibold text-blue-600 shadow-lg transition hover:bg-gray-100"
@@ -20,7 +20,7 @@ export default function CallToAction() {
         </div>
         <Link
           href="/sell"
-          className="inline-flex items-center justify-center rounded-lg border-2 border-white px-8 py-3 font-semibold text-white transition hover:bg-white hover:text-blue-600"
+          className="inline-flex items-center justify-center rounded-lg border-2 border-white/80 px-8 py-3 font-semibold text-white transition hover:bg-white hover:text-blue-600"
         >
           <Plus className="mr-2" size={20} />
           ลงประกาศของคุณ

--- a/components/featured-properties.tsx
+++ b/components/featured-properties.tsx
@@ -25,45 +25,43 @@ export default function FeaturedProperties() {
   }
 
   return (
-    <section className="py-16">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="mb-12 text-center">
-          <h2 className="mb-4 text-3xl font-bold text-gray-800 md:text-4xl">อสังหาริมทรัพย์แนะนำ</h2>
-          <p className="text-lg text-gray-600">คัดสรรอสังหาริมทรัพย์พิเศษเพื่อคุณ</p>
-        </div>
-
-        {loading ? (
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-            {Array.from({ length: 3 }).map((_, index) => (
-              <div
-                key={index}
-                className="flex h-full flex-col overflow-hidden rounded-2xl border bg-white p-4 shadow-sm animate-pulse"
-              >
-                <div className="mb-4 h-40 w-full rounded-xl bg-gray-200" />
-                <div className="space-y-3">
-                  <div className="h-4 w-3/4 rounded bg-gray-200" />
-                  <div className="h-4 w-1/2 rounded bg-gray-200" />
-                  <div className="h-4 w-full rounded bg-gray-200" />
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : error ? (
-          <p className="text-center text-sm text-red-600">{error}</p>
-        ) : featuredProperties.length === 0 ? (
-          <p className="text-center text-gray-500">ยังไม่มีประกาศแนะนำในขณะนี้</p>
-        ) : (
-          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-            {featuredProperties.map((property) => (
-              <UserPropertyCard
-                key={property.id}
-                property={property}
-                onViewDetails={handleViewDetails}
-              />
-            ))}
-          </div>
-        )}
+    <section className="surface-card px-6 py-12 sm:py-16">
+      <div className="mb-12 text-center">
+        <h2 className="mb-4 text-3xl font-bold text-gray-800 md:text-4xl">อสังหาริมทรัพย์แนะนำ</h2>
+        <p className="text-lg text-gray-600">คัดสรรอสังหาริมทรัพย์พิเศษเพื่อคุณ</p>
       </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/80 bg-white/90 p-4 shadow-sm shadow-slate-200/60 animate-pulse"
+            >
+              <div className="mb-4 h-40 w-full rounded-xl bg-slate-200/80" />
+              <div className="space-y-3">
+                <div className="h-4 w-3/4 rounded bg-slate-200/80" />
+                <div className="h-4 w-1/2 rounded bg-slate-200/80" />
+                <div className="h-4 w-full rounded bg-slate-200/80" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : error ? (
+        <p className="text-center text-sm text-red-600">{error}</p>
+      ) : featuredProperties.length === 0 ? (
+        <p className="text-center text-gray-500">ยังไม่มีประกาศแนะนำในขณะนี้</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {featuredProperties.map((property) => (
+            <UserPropertyCard
+              key={property.id}
+              property={property}
+              onViewDetails={handleViewDetails}
+            />
+          ))}
+        </div>
+      )}
 
       <UserPropertyModal
         open={Boolean(selectedProperty)}

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -101,8 +101,8 @@ export default function HeroSection({
     : locationFilter?.label
 
   return (
-    <section className="bg-gradient-to-br from-blue-600 via-purple-600 to-purple-700 text-white py-12 sm:py-16 lg:py-20">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+    <section className="full-bleed rounded-3xl bg-gradient-to-br from-blue-600 via-purple-600 to-purple-700 px-6 py-12 text-white shadow-2xl sm:px-10 sm:py-16 lg:px-16 lg:py-20">
+      <div className="mx-auto max-w-5xl text-center">
         <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-4 sm:mb-6 leading-tight">
           ค้นหาบ้านในฝันของคุณ
         </h1>
@@ -111,7 +111,7 @@ export default function HeroSection({
         </p>
 
         {/* Search Bar */}
-        <div className="mx-auto w-full max-w-5xl rounded-2xl bg-white p-3 shadow-2xl sm:p-4 md:p-6">
+        <div className="mx-auto w-full max-w-5xl rounded-2xl bg-white/95 p-3 shadow-2xl shadow-blue-900/20 backdrop-blur sm:p-4 md:p-6">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:gap-5 lg:[grid-template-columns:minmax(0,1.75fr)_minmax(0,1fr)_minmax(0,1fr)_auto]">
             {/* Location */}
             <div className="flex flex-col gap-2">

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -606,9 +606,9 @@ const Navigation: React.FC = () => {
 
   return (
     <>
-      <nav className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-        <div className="container mx-auto px-4">
-          <div className="flex h-14 sm:h-16 w-full items-center">
+      <nav className="sticky top-0 z-50 w-full border-b border-slate-200/70 bg-white/90 shadow-sm backdrop-blur-lg supports-[backdrop-filter]:bg-white/70">
+        <div className="mx-auto flex w-full max-w-7xl items-center px-4 sm:px-6 lg:px-8">
+          <div className="flex h-14 w-full items-center sm:h-16">
             {/* Logo */}
             <div className="flex flex-1 items-center">
               <Link href="/" className="flex items-center space-x-2">

--- a/components/property-listings.tsx
+++ b/components/property-listings.tsx
@@ -253,27 +253,27 @@ export default function PropertyListings({
   }
 
   return (
-    <section id="property-listings" className="bg-white py-16">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col gap-8 lg:flex-row">
+    <section id="property-listings" className="surface-card px-6 py-12 sm:py-16">
+      <div className="flex flex-col gap-10 lg:flex-row">
           {/* Filters Sidebar */}
           <div className="lg:w-1/4">
-            <div className="sticky top-24 rounded-lg bg-gray-50 p-4 sm:p-6">
-              <div className="mb-4 flex items-center justify-between sm:mb-6">
-                <h3 className="text-lg font-semibold text-gray-800 sm:text-xl">ตัวกรอง</h3>
-                <button
-                  className="text-sm text-blue-600 hover:text-blue-700"
-                  onClick={onClearFilters}
-                >
-                  ล้างทั้งหมด
-                </button>
-              </div>
+            <div className="sticky top-28 space-y-6">
+              <div className="rounded-2xl border border-slate-200/70 bg-slate-50/70 p-4 shadow-sm sm:p-6">
+                <div className="mb-4 flex items-center justify-between sm:mb-6">
+                  <h3 className="text-lg font-semibold text-slate-800 sm:text-xl">ตัวกรอง</h3>
+                  <button
+                    className="text-sm font-medium text-blue-600 transition hover:text-blue-700"
+                    onClick={onClearFilters}
+                  >
+                    ล้างทั้งหมด
+                  </button>
+                </div>
 
               {/* Location Filter */}
               <div className="mb-4 sm:mb-6">
                 <label className="mb-2 block text-sm font-medium text-gray-700">พื้นที่การค้นหา</label>
                 {locationFilter ? (
-                  <div className="space-y-3 rounded-lg border border-blue-100 bg-blue-50 p-3 text-sm text-blue-700">
+                  <div className="space-y-3 rounded-xl border border-blue-100 bg-blue-50/80 p-3 text-sm text-blue-700">
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="inline-flex items-center rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white sm:text-sm">
                         {`ในรัศมี ${locationFilter.radiusKm.toLocaleString()} กม.`}
@@ -290,7 +290,7 @@ export default function PropertyListings({
                       <button
                         type="button"
                         onClick={onClearLocation}
-                        className="inline-flex items-center rounded-full bg-red-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-red-700 sm:text-sm"
+                        className="inline-flex items-center rounded-full bg-red-500 px-3 py-1 text-xs font-semibold text-white transition hover:bg-red-600 sm:text-sm"
                       >
                         ล้างตำแหน่ง
                       </button>
@@ -309,7 +309,7 @@ export default function PropertyListings({
                         disabled={isLocatingCurrentLocation}
                         className={`rounded-lg px-3 py-1 text-xs font-medium transition ${
                           isLocatingCurrentLocation
-                            ? "bg-blue-100 text-blue-400"
+                            ? "bg-blue-100/80 text-blue-400"
                             : "border border-blue-200 bg-white text-blue-600 hover:bg-blue-50"
                         }`}
                       >
@@ -332,7 +332,7 @@ export default function PropertyListings({
                       disabled={isLocatingCurrentLocation}
                       className={`w-full rounded-lg border px-4 py-3 text-sm font-medium transition ${
                         isLocatingCurrentLocation
-                          ? "border-blue-200 bg-blue-100 text-blue-400"
+                          ? "border-blue-200 bg-blue-100/80 text-blue-400"
                           : "border-blue-200 bg-white text-blue-600 hover:bg-blue-50"
                       }`}
                     >


### PR DESCRIPTION
## Summary
- introduce global page shell utilities and gradient background to unify spacing across pages
- refresh navigation, home hero, and shared call-to-action sections with rounded full-bleed treatments
- update buy and search experiences with surface cards and refined property listing filters

## Testing
- npm run lint *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e5466a91ec8321aec738bff5c2bf72